### PR TITLE
Add not required to molten fluid tags

### DIFF
--- a/src/main/resources/data/boss_tools/tags/fluids/molten_desh.json
+++ b/src/main/resources/data/boss_tools/tags/fluids/molten_desh.json
@@ -1,7 +1,13 @@
 {
-  "replace": false,
-  "values": [
-    "boss_tools:molten_desh",
-    "boss_tools:flowing_molten_desh"
-  ]
+	"replace": false,
+	"values": [
+		{
+			"id": "boss_tools:molten_desh",
+			"required": false
+		},
+		{
+			"id": "boss_tools:flowing_molten_desh",
+			"required": false
+		}
+	]
 }

--- a/src/main/resources/data/boss_tools/tags/fluids/molten_silicon.json
+++ b/src/main/resources/data/boss_tools/tags/fluids/molten_silicon.json
@@ -1,7 +1,13 @@
 {
-  "replace": false,
-  "values": [
-    "boss_tools:molten_silicon",
-    "boss_tools:flowing_molten_silicon"
-  ]
+	"replace": false,
+	"values": [
+		{
+			"id": "boss_tools:molten_silicon",
+			"required": false
+		},
+		{
+			"id": "boss_tools:flowing_molten_silicon",
+			"required": false
+		}
+	]
 }


### PR DESCRIPTION
> "require": false

^ will ignore when object(block, item, fluid) not exist
so, it can remove below error messages
```
[23:16:41] [Worker-Main-17/ERROR]: Couldn't load tag boss_tools:molten_silicon as it is missing following references: boss_tools:molten_silicon (from main),boss_tools:flowing_molten_silicon (from main)
[23:16:41] [Worker-Main-17/ERROR]: Couldn't load tag forge:molten_silicon as it is missing following references: #boss_tools:molten_silicon (from main)
[23:16:41] [Worker-Main-17/ERROR]: Couldn't load tag boss_tools:molten_desh as it is missing following references: boss_tools:molten_desh (from main),boss_tools:flowing_molten_desh (from main)
[23:16:41] [Worker-Main-17/ERROR]: Couldn't load tag forge:molten_desh as it is missing following references: #boss_tools:molten_desh (from main)
[23:16:41] [Worker-Main-17/ERROR]: Couldn't load tag tconstruct:metal_like as it is missing following references: #forge:molten_desh (from main),#forge:molten_silicon (from main)
```
