### PR TITLE
add safety to machine save, load

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/machines/WaterPump.java
+++ b/src/main/java/net/mrscauthd/boss_tools/machines/WaterPump.java
@@ -11,7 +11,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.phys.Vec3;

--- a/src/main/java/net/mrscauthd/boss_tools/machines/tile/AbstractMachineBlockEntity.java
+++ b/src/main/java/net/mrscauthd/boss_tools/machines/tile/AbstractMachineBlockEntity.java
@@ -146,7 +146,7 @@ public abstract class AbstractMachineBlockEntity extends RandomizableContainerBl
 		this.deserializeCompoents(this.getPowerSystems(), compound.getCompound("powerSystems"));
 	}
 
-	public <T> void deserializeCompoents(Map<ResourceLocation, T> registry, CompoundTag compound) {
+	public <T> void deserializeCompoents(Map<ResourceLocation, T> registry, @Nonnull CompoundTag compound) {
 		for (Entry<ResourceLocation, T> entry : registry.entrySet()) {
 			Tag tag = compound.get(entry.getKey().toString());
 
@@ -158,7 +158,7 @@ public abstract class AbstractMachineBlockEntity extends RandomizableContainerBl
 
 	@SuppressWarnings("unchecked")
 	public <T> void deserializeComponent(ResourceLocation name, @Nonnull T component, @Nonnull Tag tag) {
-		if (tag == null) {
+		if (component == null || tag == null) {
 			return;
 		} else if (component instanceof INBTSerializable<?>) {
 			((INBTSerializable<Tag>) component).deserializeNBT(tag);
@@ -207,7 +207,9 @@ public abstract class AbstractMachineBlockEntity extends RandomizableContainerBl
 	@SuppressWarnings("unchecked")
 	@Nullable
 	public <T> Tag serializeComponent(ResourceLocation name, @Nonnull T component) {
-		if (component instanceof INBTSerializable<?>) {
+		if (component == null) {
+			return null;
+		} else if (component instanceof INBTSerializable<?>) {
 			return ((INBTSerializable<Tag>) component).serializeNBT();
 		} else if (component instanceof EnergyStorage) {
 			return ((EnergyStorage) component).serializeNBT();


### PR DESCRIPTION
1. add safety if to machine data save, load
    it will prevent when saving, loading tag is null
    (e.g. mod update to existed world)
2. and add Nonull, Nullable annotation
    other modder can know usage parameter by annotation

Maybe it just my over worry