### PR TITLE
add coal lantern tinkers compat recipes

### DIFF
--- a/src/main/resources/data/beyond_earth/recipes/smeltery/casting/metal/iron/coal_lantern.json
+++ b/src/main/resources/data/beyond_earth/recipes/smeltery/casting/metal/iron/coal_lantern.json
@@ -1,0 +1,19 @@
+{
+  "type": "tconstruct:casting_table",
+  "conditions": [
+    {
+      "modid": "tconstruct",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "cast": {
+    "item": "beyond_earth:coal_torch"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "tag": "forge:molten_iron",
+    "amount": 80
+  },
+  "result": "beyond_earth:coal_lantern",
+  "cooling_time": 57
+}

--- a/src/main/resources/data/beyond_earth/recipes/smeltery/melting/metal/iron/coal_lantern.json
+++ b/src/main/resources/data/beyond_earth/recipes/smeltery/melting/metal/iron/coal_lantern.json
@@ -1,0 +1,18 @@
+{
+  "type": "tconstruct:melting",
+  "conditions": [
+    {
+      "modid": "tconstruct",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "ingredient": {
+    "item": "beyond_earth:coal_lantern"
+  },
+  "result": {
+    "fluid": "tconstruct:molten_iron",
+    "amount": 80
+  },
+  "temperature": 800,
+  "time": 57
+}


### PR DESCRIPTION
restore from 1.16

tinkers provide lantern, soul_lantern melting/casting recipes
this recipe is that's coal_lantern version

![image](https://user-images.githubusercontent.com/44163945/149343017-dc35425e-2386-4a7d-b2aa-a47e7c761112.png)
![image](https://user-images.githubusercontent.com/44163945/149343032-a995b8a7-1fe5-4897-a1fb-10d6128c9bf0.png)
