### PR TITLE
fix #64

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/crafting/GeneratingRecipe.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/crafting/GeneratingRecipe.java
@@ -20,26 +20,25 @@ public class GeneratingRecipe extends BeyondEarthRecipe implements Predicate<Ite
 
 	public static final int SLOT_FUEL = 0;
 
-	private final Ingredient ingredient;
+	private final Ingredient input;
 	private final int burnTime;
 
 	public GeneratingRecipe(ResourceLocation id, JsonObject json) {
 		super(id, json);
-		JsonObject inputJson = GsonHelper.getAsJsonObject(json, "input");
-		this.ingredient = Ingredient.fromJson(GsonHelper.getAsJsonObject(inputJson, "ingredient"));
+		this.input = Ingredient.fromJson(GsonHelper.getAsJsonObject(json, "input"));
 		this.burnTime = GsonHelper.getAsInt(json, "burnTime");
 	}
 
 	public GeneratingRecipe(ResourceLocation id, FriendlyByteBuf buffer) {
 		super(id, buffer);
 
-		this.ingredient = Ingredient.fromNetwork(buffer);
+		this.input = Ingredient.fromNetwork(buffer);
 		this.burnTime = buffer.readInt();
 	}
 
 	public GeneratingRecipe(ResourceLocation id, Ingredient ingredient, int burnTime) {
 		super(id);
-		this.ingredient = ingredient;
+		this.input = ingredient;
 		this.burnTime = burnTime;
 	}
 
@@ -47,7 +46,7 @@ public class GeneratingRecipe extends BeyondEarthRecipe implements Predicate<Ite
 	public void write(FriendlyByteBuf buffer) {
 		super.write(buffer);
 
-		this.getIngredient().toNetwork(buffer);
+		this.getInput().toNetwork(buffer);
 		buffer.writeInt(this.getBurnTime());
 	}
 
@@ -72,17 +71,17 @@ public class GeneratingRecipe extends BeyondEarthRecipe implements Predicate<Ite
 
 	@Override
 	public boolean test(ItemStack ingredient) {
-		return this.ingredient.test(ingredient);
+		return this.input.test(ingredient);
 	}
 
-	public Ingredient getIngredient() {
-		return this.ingredient;
+	public Ingredient getInput() {
+		return this.input;
 	}
 
 	@Override
 	public NonNullList<Ingredient> getIngredients() {
 		NonNullList<Ingredient> list = super.getIngredients();
-		list.add(this.getIngredient());
+		list.add(this.getInput());
 		return list;
 	}
 

--- a/src/main/java/net/mrscauthd/beyond_earth/crafting/IngredientStack.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/crafting/IngredientStack.java
@@ -21,7 +21,7 @@ public final class IngredientStack {
 	public IngredientStack(JsonElement json) {
 		if (json instanceof JsonObject) {
 			JsonObject jsonObject = (JsonObject) json;
-			this.ingredient = Ingredient.fromJson(jsonObject);
+			this.ingredient = Ingredient.fromJson(GsonHelper.getAsJsonObject(jsonObject, "ingredient"));
 			this.count = GsonHelper.getAsInt(jsonObject, "count", this.count);
 		} else if (json instanceof JsonArray) {
 			this.ingredient = Ingredient.fromJson(json);

--- a/src/main/java/net/mrscauthd/beyond_earth/crafting/ItemStackToItemStackRecipe.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/crafting/ItemStackToItemStackRecipe.java
@@ -13,41 +13,40 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.CraftingHelper;
 
 public abstract class ItemStackToItemStackRecipe extends BeyondEarthRecipe implements Predicate<ItemStack> {
-	private final Ingredient ingredient;
+	private final Ingredient input;
 	private final ItemStack output;
 	private final int cookTime;
 
 	public ItemStackToItemStackRecipe(ResourceLocation id, JsonObject json) {
 		super(id, json);
-		JsonObject inputJson = GsonHelper.getAsJsonObject(json, "input");
-		this.ingredient = Ingredient.fromJson(GsonHelper.getAsJsonObject(inputJson, "ingredient"));
+		this.input = Ingredient.fromJson(GsonHelper.getAsJsonObject(json, "input"));
 		this.output = CraftingHelper.getItemStack(GsonHelper.getAsJsonObject(json, "output"), true);
 		this.cookTime = GsonHelper.getAsInt(json, "cookTime");
 	}
 
 	public ItemStackToItemStackRecipe(ResourceLocation id, FriendlyByteBuf buffer) {
 		super(id, buffer);
-		this.ingredient = Ingredient.fromNetwork(buffer);
+		this.input = Ingredient.fromNetwork(buffer);
 		this.output = buffer.readItem();
 		this.cookTime = buffer.readInt();
 	}
 
 	public ItemStackToItemStackRecipe(ResourceLocation id, Ingredient ingredient, ItemStack output, int cookTime) {
 		super(id);
-		this.ingredient = ingredient;
+		this.input = ingredient;
 		this.output = output.copy();
 		this.cookTime = cookTime;
 	}
 
 	public void write(FriendlyByteBuf buffer) {
-		this.getIngredient().toNetwork(buffer);
+		this.getInput().toNetwork(buffer);
 		buffer.writeItem(this.getOutput());
 		buffer.writeInt(this.getCookTime());
 	}
 
 	@Override
 	public boolean test(ItemStack stack) {
-		return this.ingredient.test(stack);
+		return this.input.test(stack);
 	}
 
 	@Override
@@ -62,12 +61,12 @@ public abstract class ItemStackToItemStackRecipe extends BeyondEarthRecipe imple
 	@Override
 	public NonNullList<Ingredient> getIngredients() {
 		NonNullList<Ingredient> list = super.getIngredients();
-		list.add(this.getIngredient());
+		list.add(this.getInput());
 		return list;
 	}
 
-	public Ingredient getIngredient() {
-		return this.ingredient;
+	public Ingredient getInput() {
+		return this.input;
 	}
 
 	public int getCookTime() {

--- a/src/main/resources/data/beyond_earth/recipes/compressing/compressed_calorite.json
+++ b/src/main/resources/data/beyond_earth/recipes/compressing/compressed_calorite.json
@@ -1,13 +1,11 @@
 {
-   "type":"beyond_earth:compressing",
-   "input":{
-      "ingredient":{
-         "tag":"forge:ingots/calorite"
-      }
-   },
-   "output":{
-      "item":"beyond_earth:compressed_calorite",
-      "count":1
-   },
-   "cookTime":200
+	"type": "beyond_earth:compressing",
+	"input": {
+		"tag": "forge:ingots/calorite"
+	},
+	"output": {
+		"item": "beyond_earth:compressed_calorite",
+		"count": 1
+	},
+	"cookTime": 200
 }

--- a/src/main/resources/data/beyond_earth/recipes/compressing/compressed_desh.json
+++ b/src/main/resources/data/beyond_earth/recipes/compressing/compressed_desh.json
@@ -1,13 +1,11 @@
 {
-   "type":"beyond_earth:compressing",
-   "input":{
-      "ingredient":{
-         "tag":"forge:ingots/desh"
-      }
-   },
-   "output":{
-      "item":"beyond_earth:compressed_desh",
-      "count":1
-   },
-   "cookTime":200
+	"type": "beyond_earth:compressing",
+	"input": {
+		"tag": "forge:ingots/desh"
+	},
+	"output": {
+		"item": "beyond_earth:compressed_desh",
+		"count": 1
+	},
+	"cookTime": 200
 }

--- a/src/main/resources/data/beyond_earth/recipes/compressing/compressed_ostrum.json
+++ b/src/main/resources/data/beyond_earth/recipes/compressing/compressed_ostrum.json
@@ -1,13 +1,11 @@
 {
-   "type":"beyond_earth:compressing",
-   "input":{
-      "ingredient":{
-         "tag":"forge:ingots/ostrum"
-      }
-   },
-   "output":{
-      "item":"beyond_earth:compressed_ostrum",
-      "count":1
-   },
-   "cookTime":200
+	"type": "beyond_earth:compressing",
+	"input": {
+		"tag": "forge:ingots/ostrum"
+	},
+	"output": {
+		"item": "beyond_earth:compressed_ostrum",
+		"count": 1
+	},
+	"cookTime": 200
 }

--- a/src/main/resources/data/beyond_earth/recipes/compressing/compressed_steel.json
+++ b/src/main/resources/data/beyond_earth/recipes/compressing/compressed_steel.json
@@ -1,13 +1,11 @@
 {
-   "type":"beyond_earth:compressing",
-   "input":{
-      "ingredient":{
-         "tag":"forge:ingots/steel"
-      }
-   },
-   "output":{
-      "item":"beyond_earth:compressed_steel",
-      "count":1
-   },
-   "cookTime":200
+	"type": "beyond_earth:compressing",
+	"input": {
+		"tag": "forge:ingots/steel"
+	},
+	"output": {
+		"item": "beyond_earth:compressed_steel",
+		"count": 1
+	},
+	"cookTime": 200
 }

--- a/src/main/resources/data/beyond_earth/recipes/generating/charcoal_block.json
+++ b/src/main/resources/data/beyond_earth/recipes/generating/charcoal_block.json
@@ -1,18 +1,16 @@
 {
-   "type":"beyond_earth:generating",
+	"type": "beyond_earth:generating",
 	"conditions": [
-    {
-		"value": {
-			"tag": "forge:storage_blocks/charcoal",
-			"type": "forge:tag_empty"
-		},
-		"type": "forge:not"
-    }
-  ],
-   "input":{
-      "ingredient":{
-         "tag":"forge:storage_blocks/charcoal"
-      }
-   },
-   "burnTime":4000
+		{
+			"value": {
+				"tag": "forge:storage_blocks/charcoal",
+				"type": "forge:tag_empty"
+			},
+			"type": "forge:not"
+		}
+	],
+	"input": {
+		"tag": "forge:storage_blocks/charcoal"
+	},
+	"burnTime": 4000
 }

--- a/src/main/resources/data/beyond_earth/recipes/generating/coal_block.json
+++ b/src/main/resources/data/beyond_earth/recipes/generating/coal_block.json
@@ -1,9 +1,7 @@
 {
-   "type":"beyond_earth:generating",
-   "input":{
-      "ingredient":{
-         "tag":"forge:storage_blocks/coal"
-      }
-   },
-   "burnTime":4000
+	"type": "beyond_earth:generating",
+	"input": {
+		"tag": "forge:storage_blocks/coal"
+	},
+	"burnTime": 4000
 }

--- a/src/main/resources/data/beyond_earth/recipes/generating/coal_coke.json
+++ b/src/main/resources/data/beyond_earth/recipes/generating/coal_coke.json
@@ -1,18 +1,16 @@
 {
-   "type":"beyond_earth:generating",
+	"type": "beyond_earth:generating",
 	"conditions": [
-    {
-		"value": {
-			"tag": "forge:coal_coke",
-			"type": "forge:tag_empty"
-		},
-		"type": "forge:not"
-    }
-  ],
-   "input":{
-      "ingredient":{
-         "tag":"forge:coal_coke"
-      }
-   },
-   "burnTime":800
+		{
+			"value": {
+				"tag": "forge:coal_coke",
+				"type": "forge:tag_empty"
+			},
+			"type": "forge:not"
+		}
+	],
+	"input": {
+		"tag": "forge:coal_coke"
+	},
+	"burnTime": 800
 }

--- a/src/main/resources/data/beyond_earth/recipes/generating/coal_coke_block.json
+++ b/src/main/resources/data/beyond_earth/recipes/generating/coal_coke_block.json
@@ -1,18 +1,16 @@
 {
-   "type":"beyond_earth:generating",
+	"type": "beyond_earth:generating",
 	"conditions": [
-    {
-		"value": {
-			"tag": "forge:storage_blocks/coal_coke",
-			"type": "forge:tag_empty"
-		},
-		"type": "forge:not"
-    }
-  ],
-   "input":{
-      "ingredient":{
-         "tag":"forge:storage_blocks/coal_coke"
-      }
-   },
-   "burnTime":8000
+		{
+			"value": {
+				"tag": "forge:storage_blocks/coal_coke",
+				"type": "forge:tag_empty"
+			},
+			"type": "forge:not"
+		}
+	],
+	"input": {
+		"tag": "forge:storage_blocks/coal_coke"
+	},
+	"burnTime": 8000
 }

--- a/src/main/resources/data/beyond_earth/recipes/generating/coals.json
+++ b/src/main/resources/data/beyond_earth/recipes/generating/coals.json
@@ -1,9 +1,7 @@
 {
-   "type":"beyond_earth:generating",
-   "input":{
-      "ingredient":{
-         "tag":"minecraft:coals"
-      }
-   },
-   "burnTime":400
+	"type": "beyond_earth:generating",
+	"input": {
+		"tag": "minecraft:coals"
+	},
+	"burnTime": 400
 }

--- a/src/main/resources/data/beyond_earth/recipes/space_station/space_station.json
+++ b/src/main/resources/data/beyond_earth/recipes/space_station/space_station.json
@@ -2,19 +2,27 @@
 	"type": "beyond_earth:space_station",
 	"ingredients": [
 		{
-			"tag": "forge:ingots/desh",
+			"ingredient": {
+				"tag": "forge:ingots/desh"
+			},
 			"count": 6
 		},
 		{
-			"tag": "forge:ingots/steel",
+			"ingredient": {
+				"tag": "forge:ingots/steel"
+			},
 			"count": 16
 		},
 		{
-			"tag": "forge:plates/iron",
+			"ingredient": {
+				"tag": "forge:plates/iron"
+			},
 			"count": 12
 		},
 		{
-			"tag": "forge:plates/desh",
+			"ingredient": {
+				"tag": "forge:plates/desh"
+			},
 			"count": 4
 		}
 	]


### PR DESCRIPTION
KubeJS patched recipe file

original file
![image](https://user-images.githubusercontent.com/44163945/151955659-cc3247ae-948d-4beb-9125-797ec994d4eb.png)

patched file
![image](https://user-images.githubusercontent.com/44163945/151955992-240c7414-6714-4cc6-85ce-0028fef4f93d.png)

so, failed to load recipe json file
[08:59:23] [Render thread/WARN]: Error parsing recipe beyond_earth:space_station/space_station[beyond_earth:space_station]: {"type":"beyond_earth:space_station","ingredients":[{"ingredient":{"tag":"forge:ingots/desh"},"count":6},{"ingredient":{"tag":"forge:ingots/steel"},"count":16},{"ingredient":{"tag":"forge:plates/iron"},"count":12},{"ingredient":{"tag":"forge:plates/desh"},"count":4}]}: com.google.gson.JsonParseException: An ingredient entry needs either a tag or an item

make recipe json file to similar with patched file