### PR TITLE
Optimise Gravity

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/events/Gravity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/events/Gravity.java
@@ -15,6 +15,10 @@ public class Gravity {
         double venus = 0.04;
         double orbit = 0.02;
 
+        if (Methods.isWorld(world, Methods.overworld)) {
+            return;
+        }
+
         if (Methods.isWorld(world, Methods.moon)) {
             gravityMath(type, entity, moon, -2.5f);
         }

--- a/src/main/java/net/mrscauthd/beyond_earth/events/Gravity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/events/Gravity.java
@@ -19,29 +19,29 @@ public class Gravity {
             gravityMath(type, entity, moon, -2.5f);
         }
 
-        if (Methods.isWorld(world, Methods.mars)) {
+        else if (Methods.isWorld(world, Methods.mars)) {
             gravityMath(type, entity, mars, -2.0f);
         }
 
-        if (Methods.isWorld(world, Methods.glacio)) {
+        else if (Methods.isWorld(world, Methods.glacio)) {
             gravityMath(type, entity, mars, -2.0f);
         }
 
-        if (Methods.isWorld(world, Methods.mercury)) {
+        else if (Methods.isWorld(world, Methods.mercury)) {
             gravityMath(type, entity, mercury, -2.5f);
         }
 
-        if (Methods.isWorld(world, Methods.venus)) {
+        else if (Methods.isWorld(world, Methods.venus)) {
             gravityMath(type, entity, venus, -2.0f);
         }
 
-        if (Methods.isOrbitWorld(world)) {
+        else if (Methods.isOrbitWorld(world)) {
             gravityMath(type, entity, orbit, -2.5f);
         }
     }
 
     public enum GravityType {
-        PLAYER,LIVING
+        PLAYER, LIVING
     }
 
     public static boolean playerGravityCheck(Player player) {
@@ -49,7 +49,7 @@ public class Gravity {
     }
 
     public static boolean livingGravityCheck(LivingEntity entity) {
-        return !entity.isFallFlying() && !entity.isInWater() && !entity.isInLava() && !entity.isNoGravity() && !(entity instanceof Player) && !Methods.AllVehiclesOr(entity) && !entity.hasEffect(MobEffects.SLOW_FALLING) && !entity.hasEffect(MobEffects.LEVITATION);
+        return !(entity instanceof Player) && !entity.isFallFlying() && !entity.isInWater() && !entity.isInLava() && !entity.isNoGravity() && !Methods.AllVehiclesOr(entity) && !entity.hasEffect(MobEffects.SLOW_FALLING) && !entity.hasEffect(MobEffects.LEVITATION);
     }
 
     public static void gravityMath(GravityType type, LivingEntity entity, double gravity, float fallDistance) {


### PR DESCRIPTION
This is a simpler version of the Gravity optimisations I made in https://github.com/MrScautHD/Beyond-Earth/pull/72

This avoids checking the world 240 times per second (6 world checks per tick event, gravity used in 2 tick events, 20 ticks per second. 6x2x20=240).

With this optimisation, it only checks 40 times per second if in the overworld (1x2x20=40) and 80 times per second if in a space world (such as moon or mars or glacio... 2x2x20). This is 83% faster in overworld and 66% faster in all other worlds.