### PR TITLE
Coal Generator can eject its energy sideways

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
@@ -48,8 +48,7 @@ public class CoalGeneratorBlockEntity extends GeneratorBlockEntity {
 	@Override
 	protected List<Direction> getEjectDirections() {
 		List<Direction> list = super.getEjectDirections();
-		list.add(Direction.UP);
-		list.add(Direction.DOWN);
+		list.addAll(Arrays.stream(Direction.values()).toList());
 		return list;
 	}
 


### PR DESCRIPTION
Coal Generator can eject its energy sideways (MAYBE, it requires testing). It makes it able to power Water Pumps.