### PR TITLE
fix infiniburn tag for 1.18.2

### DIFF
--- a/src/main/resources/data/beyond_earth/dimension_type/earth_orbit.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/earth_orbit.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 256,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": 0,
   "height": 256,
   "effects": "beyond_earth:earth_orbit"

--- a/src/main/resources/data/beyond_earth/dimension_type/glacio.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/glacio.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 384,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": -64,
   "height": 384,
   "effects": "beyond_earth:glacio"

--- a/src/main/resources/data/beyond_earth/dimension_type/glacio_orbit.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/glacio_orbit.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 256,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": 0,
   "height": 256,
   "effects": "beyond_earth:glacio_orbit"

--- a/src/main/resources/data/beyond_earth/dimension_type/mars.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/mars.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 384,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": -64,
   "height": 384,
   "effects": "beyond_earth:mars"

--- a/src/main/resources/data/beyond_earth/dimension_type/mars_orbit.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/mars_orbit.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 256,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": 0,
   "height": 256,
   "effects": "beyond_earth:mars_orbit"

--- a/src/main/resources/data/beyond_earth/dimension_type/mercury.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/mercury.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 384,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": -64,
   "height": 384,
   "effects": "beyond_earth:mercury"

--- a/src/main/resources/data/beyond_earth/dimension_type/mercury_orbit.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/mercury_orbit.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 256,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": 0,
   "height": 256,
   "effects": "beyond_earth:mercury_orbit"

--- a/src/main/resources/data/beyond_earth/dimension_type/moon.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/moon.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 384,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": 0,
   "height": 384,
   "effects": "beyond_earth:moon"

--- a/src/main/resources/data/beyond_earth/dimension_type/moon_orbit.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/moon_orbit.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 256,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": 0,
   "height": 256,
   "effects": "beyond_earth:moon_orbit"

--- a/src/main/resources/data/beyond_earth/dimension_type/venus.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/venus.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 384,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": -64,
   "height": 384,
   "effects": "beyond_earth:venus"

--- a/src/main/resources/data/beyond_earth/dimension_type/venus_orbit.json
+++ b/src/main/resources/data/beyond_earth/dimension_type/venus_orbit.json
@@ -10,7 +10,7 @@
   "coordinate_scale": 1,
   "ambient_light": 0,
   "logical_height": 256,
-  "infiniburn": "minecraft:infiniburn_overworld",
+  "infiniburn": "#minecraft:infiniburn_overworld",
   "min_y": 0,
   "height": 256,
   "effects": "beyond_earth:venus_orbit"


### PR DESCRIPTION
1. i added prefix # to dimension_type's infiburn value for 'java.util.concurrent.ExecutionException: com.google.gson.JsonParseException: Error loading registry data: Not a tag id'
1. since 1.18.2, '#' is require to prefix
1. reference : UNIVERSAL TAGS in  here https://www.minecraft.net/en-us/article/minecraft-java-edition-1-18-2
1. but it can't create new world still (like below)
1. i don't think it is our fault
1. in my guess it have to question to forge team
1. becuase other mods not updated what add own dimensions using forge

```
[15:08:38] [Render thread/WARN] [minecraft/Minecraft]: Failed to load datapacks, can't proceed with server load
java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Trying to access unbound value 'ResourceKey[minecraft:dimension / beyond_earth:earth_orbit]' from registry Registry[ResourceKey[minecraft:root / minecraft:dimension] (Stable)]
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396) ~[?:?] {}
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[?:?] {}
	at net.minecraft.client.Minecraft.makeWorldStem(Minecraft.java:2078) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.doLoadLevel(Minecraft.java:1908) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.createLevel(Minecraft.java:1870) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screens.worldselection.CreateWorldScreen.onCreate(CreateWorldScreen.java:246) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screens.worldselection.CreateWorldScreen.lambda$init$13(CreateWorldScreen.java:195) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.components.Button.onPress(Button.java:29) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.components.AbstractButton.onClick(AbstractButton.java:17) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.components.AbstractWidget.mouseClicked(AbstractWidget.java:111) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.components.events.ContainerEventHandler.mouseClicked(ContainerEventHandler.java:28) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHandler.lambda$onPress$0(MouseHandler.java:88) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.gui.screens.Screen.wrapScreenError(Screen.java:528) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHandler.onPress(MouseHandler.java:85) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.MouseHandler.lambda$setup$4(MouseHandler.java:185) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.util.thread.BlockableEventLoop.execute(BlockableEventLoop.java:90) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.client.MouseHandler.lambda$setup$5(MouseHandler.java:184) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:36) ~[lwjgl-glfw-3.2.2.jar%2354!/:build 10] {}
	at org.lwjgl.system.JNI.invokeV(Native Method) ~[lwjgl-3.2.2.jar%2360!/:build 10] {}
	at org.lwjgl.glfw.GLFW.glfwWaitEventsTimeout(GLFW.java:3174) ~[lwjgl-glfw-3.2.2.jar%2354!/:build 10] {}
	at com.mojang.blaze3d.systems.RenderSystem.limitDisplayFPS(RenderSystem.java:187) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.runTick(Minecraft.java:1069) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.run(Minecraft.java:663) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.main.Main.main(Main.java:205) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?] {}
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?] {}
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?] {}
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?] {}
	at net.minecraftforge.fml.loading.targets.ForgeClientUserdevLaunchHandler.lambda$launchService$0(ForgeClientUserdevLaunchHandler.java:38) ~[fmlloader-1.18.2-40.0.2.jar%230!/:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-9.1.3.jar%2310!/:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-9.1.3.jar%2310!/:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-9.1.3.jar%2310!/:?] {}
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-9.1.3.jar%2310!/:?] {}
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-9.1.3.jar%2310!/:?] {}
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-9.1.3.jar%2310!/:?] {}
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-9.1.3.jar%2310!/:?] {}
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:149) [bootstraplauncher-1.0.0.jar:?] {}
Caused by: java.lang.IllegalStateException: Trying to access unbound value 'ResourceKey[minecraft:dimension / beyond_earth:earth_orbit]' from registry Registry[ResourceKey[minecraft:root / minecraft:dimension] (Stable)]
	at net.minecraft.core.Holder$Reference.value(Holder.java:136) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B}
	at com.google.common.collect.Maps$9.transformEntry(Maps.java:2053) ~[guava-31.0.1-jre.jar%231!/:?] {}
	at com.google.common.collect.Maps$12.getValue(Maps.java:2101) ~[guava-31.0.1-jre.jar%231!/:?] {}
	at net.minecraft.world.level.dimension.LevelStem.sortMap(LevelStem.java:69) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading}
	at com.mojang.datafixers.util.Pair.mapFirst(Pair.java:64) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Decoder$2.lambda$decode$0(Decoder.java:63) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at java.util.Optional.map(Optional.java:260) ~[?:?] {}
	at com.mojang.serialization.DataResult.lambda$map$5(DataResult.java:112) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.datafixers.util.Either$Right.mapBoth(Either.java:94) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.DataResult.map(DataResult.java:110) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Decoder$2.decode(Decoder.java:63) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Codec$2.decode(Codec.java:71) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Decoder.parse(Decoder.java:18) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.codecs.FieldDecoder.decode(FieldDecoder.java:29) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.MapCodec$1.decode(MapCodec.java:34) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.codecs.RecordCodecBuilder$Instance$5.decode(RecordCodecBuilder.java:324) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.codecs.RecordCodecBuilder$2.decode(RecordCodecBuilder.java:107) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.MapDecoder.lambda$compressedDecode$0(MapDecoder.java:52) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.DataResult.lambda$flatMap$10(DataResult.java:138) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.datafixers.util.Either$Left.map(Either.java:38) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.DataResult.flatMap(DataResult.java:136) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.MapDecoder.compressedDecode(MapDecoder.java:52) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.MapCodec$MapCodecCodec.decode(MapCodec.java:91) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Decoder$2.decode(Decoder.java:63) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Codec$2.decode(Codec.java:71) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Decoder$1.decode(Decoder.java:49) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Codec$2.decode(Codec.java:71) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.Decoder.parse(Decoder.java:18) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at net.minecraft.client.Minecraft.lambda$createLevel$33(Minecraft.java:1878) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at com.mojang.serialization.DataResult.lambda$flatMap$10(DataResult.java:138) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.datafixers.util.Either$Left.map(Either.java:38) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at com.mojang.serialization.DataResult.flatMap(DataResult.java:136) ~[datafixerupper-4.1.27.jar%2339!/:?] {}
	at net.minecraft.client.Minecraft.lambda$createLevel$34(Minecraft.java:1877) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.WorldStem.load(WorldStem.java:31) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading}
	at net.minecraft.client.Minecraft.makeWorldStem(Minecraft.java:2076) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	... 34 more
```