### PR TITLE
Fix PlanetSelectionGuiWindow crash with JEI

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/jei/JeiPlugin.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/jei/JeiPlugin.java
@@ -162,7 +162,7 @@ public class JeiPlugin implements IModPlugin {
 
 		registration.addGuiContainerHandler(RocketGuiWindow.class, new RocketGuiContainerHandler());
 		registration.addGuiContainerHandler(RoverGuiWindow.class, new RoverGuiContainerHandler());
-		registration.addGuiContainerHandler(PlanetSelectionGuiWindow.class, new PlanetSlecetionGuiJeiHandler());
+		registration.addGuiScreenHandler(PlanetSelectionGuiWindow.class, new PlanetSlecetionGuiJeiHandler());
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/jei/jeiguihandlers/PlanetSlecetionGuiJeiHandler.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/jei/jeiguihandlers/PlanetSlecetionGuiJeiHandler.java
@@ -1,24 +1,19 @@
 package net.mrscauthd.beyond_earth.jei.jeiguihandlers;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
-import mezz.jei.api.gui.handlers.IGuiContainerHandler;
-import net.minecraft.client.renderer.Rect2i;
+import mezz.jei.api.gui.handlers.IGuiProperties;
+import mezz.jei.api.gui.handlers.IScreenHandler;
 import net.mrscauthd.beyond_earth.gui.screens.planetselection.PlanetSelectionGuiWindow;
 
-public class PlanetSlecetionGuiJeiHandler implements IGuiContainerHandler<PlanetSelectionGuiWindow> {
+public class PlanetSlecetionGuiJeiHandler implements IScreenHandler<PlanetSelectionGuiWindow> {
 
 	public PlanetSlecetionGuiJeiHandler() {
 
 	}
 
 	@Override
-	public List<Rect2i> getGuiExtraAreas(PlanetSelectionGuiWindow containerScreen) {
-		List<Rect2i> list = new ArrayList<>();
-
-		list.add(new Rect2i(0, 0, containerScreen.width, containerScreen.height));
-
-		return list;
+	public @Nullable IGuiProperties apply(PlanetSelectionGuiWindow guiScreen) {
+		return null;
 	}
 }


### PR DESCRIPTION
### Cause

1. It seem JEI bug, when show item list (on right of screen)
2. JEI calculate list's bounds using opened container
3. PlanetSelectionGui is container, and it takes up the entire screen
4. So, there is no space for item list
5. In other words, calculated list's width was negative value

### Stacktrace

```Java
Caused by: java.lang.IllegalArgumentException: width must be greater or equal 0
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145) ~[guava-31.0.1-jre.jar%231!/:?]
	at mezz.jei.util.ImmutableRect2i.<init>(ImmutableRect2i.java:29) ~[jei-1.18.2-9.4.3.122_mapped_official_1.18.2.jar%2384!/:9.4.3.122]
	at mezz.jei.util.ImmutableRect2i.cropLeft(ImmutableRect2i.java:121) ~[jei-1.18.2-9.4.3.122_mapped_official_1.18.2.jar%2384!/:9.4.3.122]
	at mezz.jei.gui.overlay.IngredientListOverlay.createDisplayArea(IngredientListOverlay.java:89) ~[jei-1.18.2-9.4.3.122_mapped_official_1.18.2.jar%2384!/:9.4.3.122]
	at mezz.jei.gui.overlay.IngredientListOverlay.updateNewScreen(IngredientListOverlay.java:111) ~[jei-1.18.2-9.4.3.122_mapped_official_1.18.2.jar%2384!/:9.4.3.122]
	at mezz.jei.gui.overlay.IngredientListOverlay.updateScreen(IngredientListOverlay.java:104) ~[jei-1.18.2-9.4.3.122_mapped_official_1.18.2.jar%2384!/:9.4.3.122]
	at mezz.jei.gui.GuiEventHandler.onDrawBackgroundEventPost(GuiEventHandler.java:70) ~[jei-1.18.2-9.4.3.122_mapped_official_1.18.2.jar%2384!/:9.4.3.122]
	at mezz.jei.util.WeakConsumer.accept(WeakConsumer.java:17) ~[jei-1.18.2-9.4.3.122_mapped_official_1.18.2.jar%2384!/:9.4.3.122]
	at net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:247) ~[eventbus-5.0.7.jar%239!/:?]
	at net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:239) ~[eventbus-5.0.7.jar%239!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-5.0.7.jar%239!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-5.0.7.jar%239!/:?]
	at net.minecraft.client.gui.screens.Screen.renderBackground(Screen.java:450) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?]
	at net.minecraft.client.gui.screens.Screen.renderBackground(Screen.java:444) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?]
	at net.mrscauthd.beyond_earth.gui.screens.planetselection.PlanetSelectionGuiWindow.render(PlanetSelectionGuiWindow.java:120) ~[%2380!/:?]
	at net.minecraftforge.client.ForgeHooksClient.drawScreenInternal(ForgeHooksClient.java:381) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2375%2381!/:?]
	at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:374) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2375%2381!/:?]
	at net.minecraft.client.renderer.GameRenderer.render(GameRenderer.java:888) ~[forge-1.18.2-40.0.2_mapped_official_1.18.2-recomp.jar%2376!/:?]
```

### Solution

1. Don't show item list on PlanetSelectionGui
2. Using IScreenHandler instead of IGuiContainerHandler

![image](https://user-images.githubusercontent.com/44163945/156925458-fe8d269d-79d0-4983-8269-94fc62b09ad9.png)

