### PR TITLE
Add missing blocks/items tags

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/ore_rates/dense.json
+++ b/src/main/resources/data/forge/tags/blocks/ore_rates/dense.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "beyond_earth:glacio_copper_ore",
+    "beyond_earth:glacio_lapis_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ore_rates/singular.json
+++ b/src/main/resources/data/forge/tags/blocks/ore_rates/singular.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    "beyond_earth:moon_iron_ore",
+    "beyond_earth:moon_desh_ore",
+    
+    "beyond_earth:mars_iron_ore",
+    "beyond_earth:mars_diamond_ore",
+    "beyond_earth:mars_ostrum_ore",
+    
+    "beyond_earth:mercury_iron_ore",
+    
+    "beyond_earth:venus_coal_ore",
+    "beyond_earth:venus_gold_ore",
+    "beyond_earth:venus_diamond_ore",
+    "beyond_earth:venus_calorite_ore",
+    
+    "beyond_earth:glacio_coal_ore",
+    "beyond_earth:glacio_iron_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ore_rates/dense.json
+++ b/src/main/resources/data/forge/tags/items/ore_rates/dense.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "beyond_earth:glacio_copper_ore",
+    "beyond_earth:glacio_lapis_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ore_rates/singular.json
+++ b/src/main/resources/data/forge/tags/items/ore_rates/singular.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    "beyond_earth:moon_iron_ore",
+    "beyond_earth:moon_desh_ore",
+    
+    "beyond_earth:mars_iron_ore",
+    "beyond_earth:mars_diamond_ore",
+    "beyond_earth:mars_ostrum_ore",
+    
+    "beyond_earth:mercury_iron_ore",
+    
+    "beyond_earth:venus_coal_ore",
+    "beyond_earth:venus_gold_ore",
+    "beyond_earth:venus_diamond_ore",
+    "beyond_earth:venus_calorite_ore",
+    
+    "beyond_earth:glacio_coal_ore",
+    "beyond_earth:glacio_iron_ore"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/coal_ores.json
+++ b/src/main/resources/data/minecraft/tags/blocks/coal_ores.json
@@ -1,0 +1,7 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:venus_coal_ore",
+		"beyond_earth:glacio_coal_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/copper_ores.json
+++ b/src/main/resources/data/minecraft/tags/blocks/copper_ores.json
@@ -1,0 +1,6 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:glacio_copper_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/diamond_ores.json
+++ b/src/main/resources/data/minecraft/tags/blocks/diamond_ores.json
@@ -1,0 +1,7 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:mars_diamond_ore",
+		"beyond_earth:venus_diamond_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/gold_ores.json
+++ b/src/main/resources/data/minecraft/tags/blocks/gold_ores.json
@@ -1,0 +1,6 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:venus_gold_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/iron_ores.json
+++ b/src/main/resources/data/minecraft/tags/blocks/iron_ores.json
@@ -1,0 +1,9 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:moon_iron_ore",
+		"beyond_earth:mars_iron_ore",
+		"beyond_earth:mercury_iron_ore",
+		"beyond_earth:glacio_iron_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/lapis_ores.json
+++ b/src/main/resources/data/minecraft/tags/blocks/lapis_ores.json
@@ -1,0 +1,6 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:glacio_lapis_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/coal_ores.json
+++ b/src/main/resources/data/minecraft/tags/items/coal_ores.json
@@ -1,0 +1,7 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:venus_coal_ore",
+		"beyond_earth:glacio_coal_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/copper_ores.json
+++ b/src/main/resources/data/minecraft/tags/items/copper_ores.json
@@ -1,0 +1,6 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:glacio_copper_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/diamond_ores.json
+++ b/src/main/resources/data/minecraft/tags/items/diamond_ores.json
@@ -1,0 +1,7 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:mars_diamond_ore",
+		"beyond_earth:venus_diamond_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/gold_ores.json
+++ b/src/main/resources/data/minecraft/tags/items/gold_ores.json
@@ -1,0 +1,6 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:venus_gold_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/iron_ores.json
+++ b/src/main/resources/data/minecraft/tags/items/iron_ores.json
@@ -1,0 +1,9 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:moon_iron_ore",
+		"beyond_earth:mars_iron_ore",
+		"beyond_earth:mercury_iron_ore",
+		"beyond_earth:glacio_iron_ore"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/lapis_ores.json
+++ b/src/main/resources/data/minecraft/tags/items/lapis_ores.json
@@ -1,0 +1,6 @@
+{
+	"replace": false,
+	"values": [
+		"beyond_earth:glacio_lapis_ore"
+	]
+}


### PR DESCRIPTION
Relate from #93 

# minecraft_xxx_ores

Actually I don't quite agree why ores need to add this tag.
Ore blocks already have a forge:ores/XXX tag.

And they are not vanilla built-in blocks,
Just They was had same output with vanilla ores.

But you said it's right to add this, 
And it's not hard to add, So i added it

![image](https://user-images.githubusercontent.com/44163945/184388018-173ec4a1-2038-4a7a-bf57-7957bfafa152.png)
Add Example

## minecraft:iron_ores

1. Moon Iron Ore
2. Mars Iron Ore
3. Mercury Iron Ore
4. Glacio Iron Ore

## minecraft:coal_ores

1. Venus Coal Ore
2. Glacio Coal ore

## minecraft:gold_ores

1. Venus Gold Ore

## minecraft:diamond_ores

1. Mars Diamond Ore
2. Venus Diamond Ore

## minecraft:copper_ores

1. Glacio Cooper Ore

## minecraft:lapis_ores

1. Glacio Lapis Lazuli Ore

# forge:ore_rates/XXX

This tag mean output amount of processing.

![image](https://user-images.githubusercontent.com/44163945/184388208-b132ef45-e1cc-4bfc-94d0-da37f636b189.png)
Add Example

# forge:ore_reates/singular

1. Moon Iron Ore
2. Moon Desh Ore
3. Mars Iron Ore
4. Mars Diamond Ore
5. Mars Ostrum Ore
6. Mercury Iron Ore
7. Venus Coal Ore
8. Venus Gold Ore
9. Venus Diamond Ore
10. Venus Calorite Ore
11. Glacio Coal Ore
12. Glacio Iron Ore

# forege:ore_rates/dense

1. Glacio Copper Ore
2. Clacio Lapis Lazuli Ore

# Undefined

1. Moon Cheese Ore
2. Moon Ice Shard Ore
3. Mars Ice Shard Ore
4. Glacio Ice Shard Ore
