### PR TITLE
Machines be configurable

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/capabilities/energy/EnergyStorageBasic.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/capabilities/energy/EnergyStorageBasic.java
@@ -35,7 +35,7 @@ public class EnergyStorageBasic extends EnergyStorage {
 		if (!this.canReceive()) {
 			return 0;
 		} else {
-			int energyReceived = Math.min(this.getMaxEnergyStored() - this.getEnergyStored(), maxReceive);
+			int energyReceived = Math.min(this.getMaxEnergyStored() - this.getEnergyStored(), Math.min(this.maxReceive, maxReceive));
 			if (!simulate && energyReceived > 0) {
 				this.energy += energyReceived;
 				Optional.ofNullable(this.getHolder()).ifPresent(h -> h.onEnergyChanged(this, +energyReceived));
@@ -50,7 +50,7 @@ public class EnergyStorageBasic extends EnergyStorage {
 		if (!this.canExtract()) {
 			return 0;
 		} else {
-			int energyExtracted = Math.min(this.getEnergyStored(), maxExtract);
+			int energyExtracted = Math.min(this.getEnergyStored(), Math.min(this.maxExtract, maxExtract));
 			if (!simulate && energyExtracted > 0) {
 				this.energy -= energyExtracted;
 				Optional.ofNullable(this.getHolder()).ifPresent(h -> h.onEnergyChanged(this, -energyExtracted));

--- a/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
@@ -80,25 +80,25 @@ public class Config {
 		BUILDER.push("Machines");
 
 		BUILDER.push("Coal Generator");
-		COAL_GENERATOR_ENERGY_GENERATION = BUILDER.comment("Set energy generation per tick, default: " + CoalGeneratorBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyGeneration", CoalGeneratorBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		COAL_GENERATOR_ENERGY_GENERATION = BUILDER.comment("Set energy generation per tick, default: " + CoalGeneratorBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyGeneration", CoalGeneratorBlockEntity.DEFAULT_ENERGY_USAGE);
 		COAL_GENERATOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		COAL_GENERATOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		BUILDER.pop();
 
 		BUILDER.push("Solar Panel");
-		SOLAR_PANEL_ENERGY_GENERATION = BUILDER.comment("Set energy generation per tick, default: " + SolarPanelBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyGeneration", SolarPanelBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		SOLAR_PANEL_ENERGY_GENERATION = BUILDER.comment("Set energy generation per tick, default: " + SolarPanelBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyGeneration", SolarPanelBlockEntity.DEFAULT_ENERGY_USAGE);
 		SOLAR_PANEL_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		SOLAR_PANEL_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		BUILDER.pop();
 
 		BUILDER.push("Compressor");
-		COMPRESSOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + CompressorBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", CompressorBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		COMPRESSOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + CompressorBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyUsage", CompressorBlockEntity.DEFAULT_ENERGY_USAGE);
 		COMPRESSOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		COMPRESSOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		BUILDER.pop();
 
 		BUILDER.push("Fuel Refinery");
-		FUEL_REFINERY_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", FuelRefineryBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		FUEL_REFINERY_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyUsage", FuelRefineryBlockEntity.DEFAULT_ENERGY_USAGE);
 		FUEL_REFINERY_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		FUEL_REFINERY_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		FUEL_REFINERY_TANK_INPUT_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankInputCapacity", FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY);
@@ -107,7 +107,7 @@ public class Config {
 		BUILDER.pop();
 
 		BUILDER.push("Oxygen Bubble Distributor");
-		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyUsageBase", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_USAGE);
 		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);
@@ -116,7 +116,7 @@ public class Config {
 		BUILDER.pop();
 
 		BUILDER.push("Oxygen Loader");
-		OXYGEN_LOADER_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		OXYGEN_LOADER_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyUsage", OxygenLoaderBlockEntity.DEFAULT_ENERGY_USAGE);
 		OXYGEN_LOADER_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		OXYGEN_LOADER_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		OXYGEN_LOADER_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY);
@@ -125,7 +125,7 @@ public class Config {
 		BUILDER.pop();
 
 		BUILDER.push("Water Pump");
-		WATER_PUMP_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", WaterPumpBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		WATER_PUMP_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyUsage", WaterPumpBlockEntity.DEFAULT_ENERGY_USAGE);
 		WATER_PUMP_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		WATER_PUMP_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		WATER_PUMP_TANK_CAPACITY = BUILDER.comment("Set water tank capacity, default: " + WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankCapacity", WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY);

--- a/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
@@ -36,29 +36,29 @@ public class Config {
 	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_TRANSFER;
-    public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_INPUT_CAPACITY;
-    public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_OUTPUT_CAPACITY;
-    public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_TRANSFER;
+	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_INPUT_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_OUTPUT_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_TRANSFER;
 
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER;
-    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY;
-    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY;
-    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER;
 
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_TRANSFER;
-    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_FLUID_CAPACITY;
-    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_OXYGEN_CAPACITY;
-    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_TRANSFER;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_FLUID_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_OXYGEN_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_TRANSFER;
 
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_TRANSFER;
-    public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_CAPACITY;
-    public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_TRANSFER;
+	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_TRANSFER;
 
 	static {
 		BUILDER.push("Beyond Earth Config");
@@ -103,7 +103,7 @@ public class Config {
 		FUEL_REFINERY_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		FUEL_REFINERY_TANK_INPUT_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankInputCapacity", FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY);
 		FUEL_REFINERY_TANK_OUTPUT_CAPACITY = BUILDER.comment("Set fluid output tank capacity, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankOutputCapacity", FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY);
-        FUEL_REFINERY_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("TankTransfer", FuelRefineryBlockEntity.DEFAULT_TANK_TRANSFER);
+		FUEL_REFINERY_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("TankTransfer", FuelRefineryBlockEntity.DEFAULT_TANK_TRANSFER);
 		BUILDER.pop();
 
 		BUILDER.push("Oxygen Bubble Distributor");
@@ -113,15 +113,15 @@ public class Config {
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY = BUILDER.comment("Set oxygen output tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("OxygenCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("FluidTransfer", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_TRANSFER);
-        BUILDER.pop();
+		BUILDER.pop();
 
 		BUILDER.push("Oxygen Loader");
 		OXYGEN_LOADER_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK);
 		OXYGEN_LOADER_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		OXYGEN_LOADER_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		OXYGEN_LOADER_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY);
-        OXYGEN_LOADER_TANK_OXYGEN_CAPACITY = BUILDER.comment("Set oxygen output tank capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("OxygenCapacity", OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY);
-        OXYGEN_LOADER_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("FluidTransfer", OxygenLoaderBlockEntity.DEFAULT_TANK_TRANSFER);
+		OXYGEN_LOADER_TANK_OXYGEN_CAPACITY = BUILDER.comment("Set oxygen output tank capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("OxygenCapacity", OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY);
+		OXYGEN_LOADER_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("FluidTransfer", OxygenLoaderBlockEntity.DEFAULT_TANK_TRANSFER);
 		BUILDER.pop();
 
 		BUILDER.push("Water Pump");
@@ -130,7 +130,7 @@ public class Config {
 		WATER_PUMP_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		WATER_PUMP_TANK_CAPACITY = BUILDER.comment("Set water tank capacity, default: " + WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankCapacity", WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY);
 		WATER_PUMP_TANK_TRANSFER = BUILDER.comment("Set water tank transfer, default: " + WaterPumpBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("TankTransfer", WaterPumpBlockEntity.DEFAULT_TANK_TRANSFER);
-        BUILDER.pop();
+		BUILDER.pop();
 
 		BUILDER.pop();
 

--- a/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
@@ -46,6 +46,8 @@ public class Config {
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MIN;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MAX;
 
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_CAPACITY;
@@ -59,6 +61,7 @@ public class Config {
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_TRANSFER;
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_TRANSFER;
+	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_WORK_INTERVAL;
 
 	static {
 		BUILDER.push("Beyond Earth Config");
@@ -113,6 +116,11 @@ public class Config {
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY = BUILDER.comment("Set oxygen output tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("OxygenCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("FluidTransfer", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_TRANSFER);
+		BUILDER.comment("Range is mean distance of each side from center", "Working area will be (range * 2) + 1", "For example, when range is 2, then working area is 3x3x3 blocks", "range is 15, then working area is 31x31x31 blocks");
+		BUILDER.push("Range");
+		OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MIN = BUILDER.comment("Default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_RANGE_MIN +" blocks").defineInRange("RangeMin", OxygenBubbleDistributorBlockEntity.DEFAULT_RANGE_MIN, 1, 49);
+		OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MAX = BUILDER.comment("Default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_RANGE_MAX +" blocks").defineInRange("RangeMax", OxygenBubbleDistributorBlockEntity.DEFAULT_RANGE_MAX, 1, 49);
+		BUILDER.pop();
 		BUILDER.pop();
 
 		BUILDER.push("Oxygen Loader");
@@ -130,6 +138,7 @@ public class Config {
 		WATER_PUMP_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		WATER_PUMP_TANK_CAPACITY = BUILDER.comment("Set water tank capacity, default: " + WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankCapacity", WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY);
 		WATER_PUMP_TANK_TRANSFER = BUILDER.comment("Set water tank transfer, default: " + WaterPumpBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("TankTransfer", WaterPumpBlockEntity.DEFAULT_TANK_TRANSFER);
+		WATER_PUMP_WORK_INTERVAL = BUILDER.comment("Set pumping interval ticks, default: " + WaterPumpBlockEntity.DEFAULT_WORK_INTERVAL +" ticks").define("WorkInterval", WaterPumpBlockEntity.DEFAULT_WORK_INTERVAL);
 		BUILDER.pop();
 
 		BUILDER.pop();

--- a/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
@@ -1,6 +1,7 @@
 package net.mrscauthd.beyond_earth.config;
 
 import net.minecraftforge.common.ForgeConfigSpec;
+import net.mrscauthd.beyond_earth.machines.tile.*;
 
 public class Config {
 	public static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
@@ -19,6 +20,35 @@ public class Config {
 	public static final ForgeConfigSpec.ConfigValue<Boolean> PLAYER_OXYGEN_SYSTEM;
 	public static final ForgeConfigSpec.ConfigValue<Boolean> ENTITY_OXYGEN_SYSTEM;
 
+	/** Machines */
+	public static final ForgeConfigSpec.ConfigValue<Integer> COAL_GENERATOR_ENERGY_GENERATION;
+	public static final ForgeConfigSpec.ConfigValue<Integer> COAL_GENERATOR_ENERGY_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> COAL_GENERATOR_ENERGY_TRANSFER;
+
+	public static final ForgeConfigSpec.ConfigValue<Integer> SOLAR_PANEL_ENERGY_GENERATION;
+	public static final ForgeConfigSpec.ConfigValue<Integer> SOLAR_PANEL_ENERGY_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> SOLAR_PANEL_ENERGY_TRANSFER;
+
+	public static final ForgeConfigSpec.ConfigValue<Integer> COMPRESSOR_ENERGY_USAGE;
+	public static final ForgeConfigSpec.ConfigValue<Integer> COMPRESSOR_ENERGY_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> COMPRESSOR_ENERGY_TRANSFER;
+
+	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_USAGE;
+	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_TRANSFER;
+
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER;
+
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_USAGE;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_TRANSFER;
+
+	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_USAGE;
+	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_CAPACITY;
+	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_TRANSFER;
+
 	static {
 		BUILDER.push("Beyond Earth Config");
 
@@ -34,6 +64,53 @@ public class Config {
 		/** Entity Systems */
 		PLAYER_OXYGEN_SYSTEM = BUILDER.comment("Enable or Disable Player Oxygen System").define("Player Oxygen System", true);
 		ENTITY_OXYGEN_SYSTEM = BUILDER.comment("Enable or Disable Entity Oxygen System").define("Entity Oxygen System", true);
+
+		/** Machines */
+		BUILDER.push("Machines");
+
+		BUILDER.push("Coal Generator");
+		COAL_GENERATOR_ENERGY_GENERATION = BUILDER.comment("Set energy generation per tick, default: " + CoalGeneratorBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyGeneration", CoalGeneratorBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		COAL_GENERATOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
+		COAL_GENERATOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", CoalGeneratorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		BUILDER.pop();
+
+		BUILDER.push("Solar Panel");
+		SOLAR_PANEL_ENERGY_GENERATION = BUILDER.comment("Set energy generation per tick, default: " + SolarPanelBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyGeneration", SolarPanelBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		SOLAR_PANEL_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
+		SOLAR_PANEL_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", SolarPanelBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		BUILDER.pop();
+
+		BUILDER.push("Compressor");
+		COMPRESSOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + CompressorBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", CompressorBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		COMPRESSOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
+		COMPRESSOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", CompressorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		BUILDER.pop();
+
+		BUILDER.push("Fuel Refinery");
+		FUEL_REFINERY_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", FuelRefineryBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		FUEL_REFINERY_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
+		FUEL_REFINERY_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		BUILDER.pop();
+
+		BUILDER.push("Oxygen Bubble Distributor");
+		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
+		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		BUILDER.pop();
+
+		BUILDER.push("Oxygen Loader");
+		OXYGEN_LOADER_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		OXYGEN_LOADER_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
+		OXYGEN_LOADER_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		BUILDER.pop();
+
+		BUILDER.push("Water Pump");
+		WATER_PUMP_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", WaterPumpBlockEntity.DEFAULT_ENERGY_PER_TICK);
+		WATER_PUMP_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
+		WATER_PUMP_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		BUILDER.pop();
+
+		BUILDER.pop();
 
 		BUILDER.pop();
 		SPEC = BUILDER.build();

--- a/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
@@ -36,18 +36,29 @@ public class Config {
 	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_ENERGY_TRANSFER;
+    public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_INPUT_CAPACITY;
+    public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_OUTPUT_CAPACITY;
+    public static final ForgeConfigSpec.ConfigValue<Integer> FUEL_REFINERY_TANK_TRANSFER;
 
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER;
+    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY;
+    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY;
+    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER;
 
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_ENERGY_TRANSFER;
+    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_FLUID_CAPACITY;
+    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_OXYGEN_CAPACITY;
+    public static final ForgeConfigSpec.ConfigValue<Integer> OXYGEN_LOADER_TANK_TRANSFER;
 
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_USAGE;
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_CAPACITY;
 	public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_ENERGY_TRANSFER;
+    public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_CAPACITY;
+    public static final ForgeConfigSpec.ConfigValue<Integer> WATER_PUMP_TANK_TRANSFER;
 
 	static {
 		BUILDER.push("Beyond Earth Config");
@@ -90,25 +101,36 @@ public class Config {
 		FUEL_REFINERY_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", FuelRefineryBlockEntity.DEFAULT_ENERGY_PER_TICK);
 		FUEL_REFINERY_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		FUEL_REFINERY_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", FuelRefineryBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		FUEL_REFINERY_TANK_INPUT_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankInputCapacity", FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY);
+		FUEL_REFINERY_TANK_OUTPUT_CAPACITY = BUILDER.comment("Set fluid output tank capacity, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankOutputCapacity", FuelRefineryBlockEntity.DEFAULT_TANK_CAPACITY);
+        FUEL_REFINERY_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + FuelRefineryBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("TankTransfer", FuelRefineryBlockEntity.DEFAULT_TANK_TRANSFER);
 		BUILDER.pop();
 
 		BUILDER.push("Oxygen Bubble Distributor");
 		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_PER_TICK);
 		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
-		BUILDER.pop();
+		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);
+		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY = BUILDER.comment("Set oxygen output tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("OxygenCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);
+		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("FluidTransfer", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_TRANSFER);
+        BUILDER.pop();
 
 		BUILDER.push("Oxygen Loader");
 		OXYGEN_LOADER_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", OxygenLoaderBlockEntity.DEFAULT_ENERGY_PER_TICK);
 		OXYGEN_LOADER_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		OXYGEN_LOADER_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenLoaderBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
+		OXYGEN_LOADER_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY);
+        OXYGEN_LOADER_TANK_OXYGEN_CAPACITY = BUILDER.comment("Set oxygen output tank capacity, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("OxygenCapacity", OxygenLoaderBlockEntity.DEFAULT_TANK_CAPACITY);
+        OXYGEN_LOADER_TANK_TRANSFER = BUILDER.comment("Set tank transfer, default: " + OxygenLoaderBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("FluidTransfer", OxygenLoaderBlockEntity.DEFAULT_TANK_TRANSFER);
 		BUILDER.pop();
 
 		BUILDER.push("Water Pump");
 		WATER_PUMP_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_PER_TICK +" FE/t").define("EnergyUsage", WaterPumpBlockEntity.DEFAULT_ENERGY_PER_TICK);
 		WATER_PUMP_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		WATER_PUMP_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", WaterPumpBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
-		BUILDER.pop();
+		WATER_PUMP_TANK_CAPACITY = BUILDER.comment("Set water tank capacity, default: " + WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("TankCapacity", WaterPumpBlockEntity.DEFAULT_TANK_CAPACITY);
+		WATER_PUMP_TANK_TRANSFER = BUILDER.comment("Set water tank transfer, default: " + WaterPumpBlockEntity.DEFAULT_TANK_TRANSFER +" mB").define("TankTransfer", WaterPumpBlockEntity.DEFAULT_TANK_TRANSFER);
+        BUILDER.pop();
 
 		BUILDER.pop();
 

--- a/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
@@ -110,7 +110,7 @@ public class Config {
 		BUILDER.pop();
 
 		BUILDER.push("Oxygen Bubble Distributor");
-		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyUsageBase", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_USAGE);
+		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE = BUILDER.comment("Set energy usage per tick, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_USAGE +" FE/t").define("EnergyUsage", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_USAGE);
 		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY = BUILDER.comment("Set energy capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY +" FE").define("EnergyCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_CAPACITY);
 		OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER = BUILDER.comment("Set energy transfer, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER +" FE").define("EnergyTransfer", OxygenBubbleDistributorBlockEntity.DEFAULT_ENERGY_STORAGE_TRANSFER);
 		OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY = BUILDER.comment("Set fluid input tank capacity, default: " + OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY + " mB").define("FluidCapacity", OxygenBubbleDistributorBlockEntity.DEFAULT_TANK_CAPACITY);

--- a/src/main/java/net/mrscauthd/beyond_earth/jei/JeiPlugin.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/jei/JeiPlugin.java
@@ -51,6 +51,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
 import net.mrscauthd.beyond_earth.capabilities.oxygen.OxygenUtil;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeTypes;
 import net.mrscauthd.beyond_earth.crafting.CompressingRecipe;
 import net.mrscauthd.beyond_earth.crafting.FuelRefiningRecipe;
@@ -390,7 +391,7 @@ public class JeiPlugin implements IModPlugin {
 		@Override
 		public List<Component> getTooltipStrings(OxygenLoaderRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
 			if (GuiHelper.isHover(this.getEnergyBounds(), mouseX, mouseY)) {
-				return Collections.singletonList(GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(FuelRefineryBlockEntity.ENERGY_PER_TICK)).build());
+				return Collections.singletonList(GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(Config.FUEL_REFINERY_ENERGY_USAGE.get())).build());
 			} else if (GuiHelper.isHover(this.getOutputTankBounds(), mouseX, mouseY)) {
 				return Collections.singletonList(GaugeTextHelper.getValueText(GaugeValueHelper.getOxygen(recipe.getOxygen())).build());
 			}
@@ -490,7 +491,7 @@ public class JeiPlugin implements IModPlugin {
 		@Override
 		public List<Component> getTooltipStrings(OxygenBubbleDistributorRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
 			if (GuiHelper.isHover(this.getEnergyBounds(), mouseX, mouseY)) {
-				return Collections.singletonList(GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(FuelRefineryBlockEntity.ENERGY_PER_TICK)).build());
+				return Collections.singletonList(GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(Config.FUEL_REFINERY_ENERGY_USAGE.get())).build());
 			} else if (GuiHelper.isHover(this.getOutputTankBounds(), mouseX, mouseY)) {
 				return Collections.singletonList(GaugeTextHelper.getValueText(GaugeValueHelper.getOxygen(recipe.getOxygen())).build());
 			}
@@ -586,7 +587,7 @@ public class JeiPlugin implements IModPlugin {
 			if (GuiHelper.isHover(this.getFireBounds(), mouseX, mouseY)) {
 				return Collections.singletonList(GaugeTextHelper.getValueText(GaugeValueHelper.getBurnTime(recipe.getBurnTime())).build());
 			} else if (GuiHelper.isHover(this.getEnergyBounds(), mouseX, mouseY)) {
-				return Collections.singletonList(GaugeTextHelper.getGeneratingPerTickText(GaugeValueHelper.getEnergy(CoalGeneratorBlockEntity.ENERGY_PER_TICK)).build());
+				return Collections.singletonList(GaugeTextHelper.getGeneratingPerTickText(GaugeValueHelper.getEnergy(Config.COAL_GENERATOR_ENERGY_GENERATION.get())).build());
 			}
 			return Collections.emptyList();
 		}
@@ -1056,7 +1057,7 @@ public class JeiPlugin implements IModPlugin {
 		@Override
 		public List<Component> getTooltipStrings(CompressingRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
 			if (GuiHelper.isHover(this.getEnergyBounds(), mouseX, mouseY)) {
-				return Collections.singletonList((GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(CompressorBlockEntity.ENERGY_PER_TICK)).build()));
+				return Collections.singletonList((GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(Config.COMPRESSOR_ENERGY_USAGE.get())).build()));
 			} else {
 				return Collections.emptyList();
 			}
@@ -1152,7 +1153,7 @@ public class JeiPlugin implements IModPlugin {
 		@Override
 		public List<Component> getTooltipStrings(FuelRefiningRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
 			if (GuiHelper.isHover(this.getEnergyBounds(), mouseX, mouseY)) {
-				return Collections.singletonList(GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(FuelRefineryBlockEntity.ENERGY_PER_TICK)).build());
+				return Collections.singletonList(GaugeTextHelper.getUsingPerTickText(GaugeValueHelper.getEnergy(Config.FUEL_REFINERY_ENERGY_USAGE.get())).build());
 			} else {
 				return Collections.emptyList();
 			}

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/CoalGeneratorBlock.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/CoalGeneratorBlock.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.gauge.GaugeTextHelper;
 import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
 import net.mrscauthd.beyond_earth.machines.tile.CoalGeneratorBlockEntity;
@@ -22,7 +23,7 @@ public class CoalGeneratorBlock extends AbstractMachineBlock<CoalGeneratorBlockE
 	@Override
 	public void appendHoverText(ItemStack itemstack, BlockGetter level, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(itemstack, level, list, flag);
-		list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getGeneratingPerTickText(GaugeValueHelper.getEnergy(CoalGeneratorBlockEntity.ENERGY_PER_TICK))));
+		list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getGeneratingPerTickText(GaugeValueHelper.getEnergy(Config.COAL_GENERATOR_ENERGY_GENERATION.get()))));
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/OxygenBubbleDistributorBlock.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/OxygenBubbleDistributorBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.machines.tile.OxygenBubbleDistributorBlockEntity;
 
 public class OxygenBubbleDistributorBlock extends AbstractMachineBlock<OxygenBubbleDistributorBlockEntity> {
@@ -35,8 +36,8 @@ public class OxygenBubbleDistributorBlock extends AbstractMachineBlock<OxygenBub
 	public void appendHoverText(ItemStack itemstack, BlockGetter level, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(itemstack, level, list, flag);
 
-		int min = OxygenBubbleDistributorBlockEntity.RANGE_MIN * 2 + 1;
-		int max = OxygenBubbleDistributorBlockEntity.RANGE_MAX * 2 + 1;
+		int min = Config.OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MIN.get() * 2 + 1;
+		int max = Config.OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MAX.get()  * 2 + 1;
 		list.add(new TranslatableComponent("tooltip." + BeyondEarthMod.MODID + ".oxygen_bubble_distributor", min, max).setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
 	}
 

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/SolarPanelBlock.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/SolarPanelBlock.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.gauge.GaugeTextHelper;
 import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
 import net.mrscauthd.beyond_earth.machines.tile.SolarPanelBlockEntity;
@@ -22,7 +23,7 @@ public class SolarPanelBlock extends AbstractMachineBlock<SolarPanelBlockEntity>
 	@Override
 	public void appendHoverText(ItemStack itemstack, BlockGetter level, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(itemstack, level, list, flag);
-		list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getGeneratingPerTickText(GaugeValueHelper.getEnergy(SolarPanelBlockEntity.ENERGY_PER_TICK))));
+		list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getGeneratingPerTickText(GaugeValueHelper.getEnergy(Config.SOLAR_PANEL_ENERGY_GENERATION.get()))));
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/WaterPump.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/WaterPump.java
@@ -15,6 +15,7 @@ import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.gauge.GaugeTextHelper;
 import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
 import net.mrscauthd.beyond_earth.machines.tile.WaterPumpBlockEntity;
@@ -90,7 +91,7 @@ public class WaterPump extends AbstractMachineBlock<WaterPumpBlockEntity> {
     @Override
 	public void appendHoverText(ItemStack itemstack, BlockGetter level, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(itemstack, level, list, flag);
-		list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getTransferPerTickText(GaugeValueHelper.getFluid(WaterPumpBlockEntity.TRANSFER_PER_TICK))));
+		list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getTransferPerTickText(GaugeValueHelper.getFluid(Config.WATER_PUMP_TANK_TRANSFER.get()))));
     }
 
     @Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/AbstractMachineBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/AbstractMachineBlockEntity.java
@@ -52,7 +52,6 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
-import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
 import net.mrscauthd.beyond_earth.capabilities.energy.IEnergyStorageHolder;
 import net.mrscauthd.beyond_earth.crafting.FluidIngredient;
 import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
@@ -63,6 +62,10 @@ import net.mrscauthd.beyond_earth.machines.AbstractMachineBlock;
 public abstract class AbstractMachineBlockEntity extends RandomizableContainerBlockEntity implements WorldlyContainer, IEnergyStorageHolder, IGaugeValuesProvider {
 
 	public static final String KEY_ACTIVATED = "activated";
+	
+
+    public static final int DEFAULT_ENERGY_STORAGE_CAPACITY = 9000;
+    public static final int DEFAULT_ENERGY_STORAGE_TRANSFER = 200;
 
 	private Map<Object, Object> selectedPrimaries;
 	private Map<ResourceLocation, IEnergyStorage> energyStorages;
@@ -449,10 +452,6 @@ public abstract class AbstractMachineBlockEntity extends RandomizableContainerBl
 	@Nullable
 	public IEnergyStorage getPrimaryEnergyStorage() {
 		return this.getPrimaryComponent(this.getEnergyStorages());
-	}
-
-	protected IEnergyStorage createEnergyStorageCommon() {
-		return new EnergyStorageBasic(this, 9000, 200, 200);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/AbstractMachineBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/AbstractMachineBlockEntity.java
@@ -62,12 +62,12 @@ import net.mrscauthd.beyond_earth.machines.AbstractMachineBlock;
 public abstract class AbstractMachineBlockEntity extends RandomizableContainerBlockEntity implements WorldlyContainer, IEnergyStorageHolder, IGaugeValuesProvider {
 
 	public static final String KEY_ACTIVATED = "activated";
-	
 
-    public static final int DEFAULT_ENERGY_STORAGE_CAPACITY = 9000;
-    public static final int DEFAULT_ENERGY_STORAGE_TRANSFER = 200;
-    public static final int DEFAULT_TANK_CAPACITY = 3000;
-    public static final int DEFAULT_TANK_TRANSFER = 256;
+
+	public static final int DEFAULT_ENERGY_STORAGE_CAPACITY = 9000;
+	public static final int DEFAULT_ENERGY_STORAGE_TRANSFER = 200;
+	public static final int DEFAULT_TANK_CAPACITY = 3000;
+	public static final int DEFAULT_TANK_TRANSFER = 256;
 
 	private Map<Object, Object> selectedPrimaries;
 	private Map<ResourceLocation, IEnergyStorage> energyStorages;

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/AbstractMachineBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/AbstractMachineBlockEntity.java
@@ -66,6 +66,8 @@ public abstract class AbstractMachineBlockEntity extends RandomizableContainerBl
 
     public static final int DEFAULT_ENERGY_STORAGE_CAPACITY = 9000;
     public static final int DEFAULT_ENERGY_STORAGE_TRANSFER = 200;
+    public static final int DEFAULT_TANK_CAPACITY = 3000;
+    public static final int DEFAULT_TANK_TRANSFER = 256;
 
 	private Map<Object, Object> selectedPrimaries;
 	private Map<ResourceLocation, IEnergyStorage> energyStorages;

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
@@ -61,12 +61,12 @@ public class CoalGeneratorBlockEntity extends GeneratorBlockEntity {
 		super.createPowerSystems(map);
 		map.put(this.powerSystemGenerating = new PowerSystemFuelGeneratingRecipe(this, this.getFuelSlot()));
 	}
-	
+
 	@Override
 	protected IEnergyStorage createGeneratingEnergyStorage() {
-	    int capacity = Config.COAL_GENERATOR_ENERGY_CAPACITY.get();
-	    int maxReceive = Config.COAL_GENERATOR_ENERGY_TRANSFER.get();
-        return new EnergyStorageBasic(this, capacity, maxReceive, capacity);
+		int capacity = Config.COAL_GENERATOR_ENERGY_CAPACITY.get();
+		int maxReceive = Config.COAL_GENERATOR_ENERGY_TRANSFER.get();
+		return new EnergyStorageBasic(this, capacity, maxReceive, capacity);
 	}
 
 	public PowerSystemFuelGeneratingRecipe getPowerSystemGenerating() {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
@@ -16,7 +16,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 public class CoalGeneratorBlockEntity extends GeneratorBlockEntity {
 
 	public static final int SLOT_FUEL = 0;
-	public static final int DEFAULT_ENERGY_PER_TICK = 2;
+	public static final int DEFAULT_ENERGY_USAGE = 2;
 
 	private PowerSystemFuelGeneratingRecipe powerSystemGenerating;
 

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CoalGeneratorBlockEntity.java
@@ -7,13 +7,16 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.energy.IEnergyStorage;
+import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.guis.screens.coalgenerator.CoalGeneratorGui;
 import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class CoalGeneratorBlockEntity extends GeneratorBlockEntity {
 
 	public static final int SLOT_FUEL = 0;
-	public static final int ENERGY_PER_TICK = 2;
+	public static final int DEFAULT_ENERGY_PER_TICK = 2;
 
 	private PowerSystemFuelGeneratingRecipe powerSystemGenerating;
 
@@ -28,7 +31,7 @@ public class CoalGeneratorBlockEntity extends GeneratorBlockEntity {
 
 	@Override
 	public int getMaxGeneration() {
-		return ENERGY_PER_TICK;
+		return Config.COAL_GENERATOR_ENERGY_GENERATION.get();
 	}
 
 	protected int getGenerationInTick() {
@@ -57,6 +60,13 @@ public class CoalGeneratorBlockEntity extends GeneratorBlockEntity {
 	protected void createPowerSystems(PowerSystemRegistry map) {
 		super.createPowerSystems(map);
 		map.put(this.powerSystemGenerating = new PowerSystemFuelGeneratingRecipe(this, this.getFuelSlot()));
+	}
+	
+	@Override
+	protected IEnergyStorage createGeneratingEnergyStorage() {
+	    int capacity = Config.COAL_GENERATOR_ENERGY_CAPACITY.get();
+	    int maxReceive = Config.COAL_GENERATOR_ENERGY_TRANSFER.get();
+        return new EnergyStorageBasic(this, capacity, maxReceive, capacity);
 	}
 
 	public PowerSystemFuelGeneratingRecipe getPowerSystemGenerating() {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CompressorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CompressorBlockEntity.java
@@ -5,6 +5,8 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.energy.IEnergyStorage;
+import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeTypes;
 import net.mrscauthd.beyond_earth.crafting.ItemStackToItemStackRecipeType;
 import net.mrscauthd.beyond_earth.guis.screens.compressor.CompressorGui;
@@ -12,7 +14,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class CompressorBlockEntity extends ItemStackToItemStackBlockEntity {
 
-	public static final int ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_PER_TICK = 1;
 
 	public CompressorBlockEntity(BlockPos pos, BlockState state) {
 		super(BlockEntitiesRegistry.COMPRESSOR_BLOCK_ENTITY.get(), pos, state);
@@ -31,7 +33,9 @@ public class CompressorBlockEntity extends ItemStackToItemStackBlockEntity {
 	@Override
 	protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
 		super.createEnergyStorages(registry);
-		registry.put(this.createEnergyStorageCommon());
+		int capacity = Config.COMPRESSOR_ENERGY_CAPACITY.get();
+		int maxTransfer = Config.COMPRESSOR_ENERGY_TRANSFER.get();
+        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
 	}
 
 	@Override
@@ -46,6 +50,6 @@ public class CompressorBlockEntity extends ItemStackToItemStackBlockEntity {
 	}
 
 	public int getBasePowerForOperation() {
-		return ENERGY_PER_TICK;
+		return Config.COMPRESSOR_ENERGY_USAGE.get();
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CompressorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CompressorBlockEntity.java
@@ -35,7 +35,7 @@ public class CompressorBlockEntity extends ItemStackToItemStackBlockEntity {
 		super.createEnergyStorages(registry);
 		int capacity = Config.COMPRESSOR_ENERGY_CAPACITY.get();
 		int maxTransfer = Config.COMPRESSOR_ENERGY_TRANSFER.get();
-        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
+		registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CompressorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/CompressorBlockEntity.java
@@ -14,7 +14,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class CompressorBlockEntity extends ItemStackToItemStackBlockEntity {
 
-	public static final int DEFAULT_ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_USAGE = 1;
 
 	public CompressorBlockEntity(BlockPos pos, BlockState state) {
 		super(BlockEntitiesRegistry.COMPRESSOR_BLOCK_ENTITY.get(), pos, state);

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
@@ -21,7 +21,9 @@ import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 import net.minecraftforge.fluids.capability.templates.FluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
+import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
 import net.mrscauthd.beyond_earth.capabilities.fluid.FluidMultiTank;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeType;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeTypes;
 import net.mrscauthd.beyond_earth.crafting.FluidIngredient;
@@ -33,7 +35,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 
-	public static final int ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_PER_TICK = 1;
 	public static final int TANK_CAPACITY = 3000;
 	public static final int TRANSFER_PER_TICK = 256;
 	public static final ResourceLocation TANK_INPUT = new ResourceLocation(BeyondEarthMod.MODID, "input");
@@ -60,7 +62,9 @@ public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 	@Override
 	protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
 		super.createEnergyStorages(registry);
-		registry.put(this.createEnergyStorageCommon());
+        int capacity = Config.FUEL_REFINERY_ENERGY_CAPACITY.get();
+        int maxTransfer = Config.FUEL_REFINERY_ENERGY_TRANSFER.get();
+        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
 	}
 
 	@Override
@@ -97,7 +101,7 @@ public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 	}
 
 	public int getBasePowerForOperation() {
-		return ENERGY_PER_TICK;
+		return Config.FUEL_REFINERY_ENERGY_USAGE.get();
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
@@ -35,7 +35,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 
-	public static final int DEFAULT_ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_USAGE = 1;
 	public static final ResourceLocation TANK_INPUT = new ResourceLocation(BeyondEarthMod.MODID, "input");
 	public static final ResourceLocation TANK_OUTPUT = new ResourceLocation(BeyondEarthMod.MODID, "output");
 	public static final int SLOT_INPUT_SOURCE = 0;

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
@@ -36,8 +36,6 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 
 	public static final int DEFAULT_ENERGY_PER_TICK = 1;
-	public static final int TANK_CAPACITY = 3000;
-	public static final int TRANSFER_PER_TICK = 256;
 	public static final ResourceLocation TANK_INPUT = new ResourceLocation(BeyondEarthMod.MODID, "input");
 	public static final ResourceLocation TANK_OUTPUT = new ResourceLocation(BeyondEarthMod.MODID, "output");
 	public static final int SLOT_INPUT_SOURCE = 0;
@@ -76,7 +74,13 @@ public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 	}
 
 	protected int getInitialTankCapacity(ResourceLocation name) {
-		return TANK_CAPACITY;
+	    if (name.equals(this.getInputTankName())) {
+	        return Config.FUEL_REFINERY_TANK_INPUT_CAPACITY.get();
+	    } else if (name.equals(this.getOutputTankName())) {
+	        return Config.FUEL_REFINERY_TANK_OUTPUT_CAPACITY.get();
+	    } else {
+	        return DEFAULT_TANK_CAPACITY;
+	    }
 	}
 
 	protected FluidTank creatTank(ResourceLocation name) {
@@ -292,7 +296,7 @@ public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 	}
 
 	public int getTransferPerTick() {
-		return TRANSFER_PER_TICK;
+		return Config.FUEL_REFINERY_TANK_TRANSFER.get();
 	}
 
 	public FluidMultiTank getTanks() {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/FuelRefineryBlockEntity.java
@@ -60,9 +60,9 @@ public class FuelRefineryBlockEntity extends AbstractMachineBlockEntity {
 	@Override
 	protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
 		super.createEnergyStorages(registry);
-        int capacity = Config.FUEL_REFINERY_ENERGY_CAPACITY.get();
-        int maxTransfer = Config.FUEL_REFINERY_ENERGY_TRANSFER.get();
-        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
+		int capacity = Config.FUEL_REFINERY_ENERGY_CAPACITY.get();
+		int maxTransfer = Config.FUEL_REFINERY_ENERGY_TRANSFER.get();
+		registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/GeneratorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/GeneratorBlockEntity.java
@@ -61,9 +61,7 @@ public abstract class GeneratorBlockEntity extends AbstractMachineBlockEntity {
 		registry.put(this.internalEnergyStorage);
 	}
 
-	protected IEnergyStorage createGeneratingEnergyStorage() {
-		return this.createEnergyStorageCommon();
-	}
+	protected abstract IEnergyStorage createGeneratingEnergyStorage();
 
 	public class EjectingTuple {
 		public final IEnergyStorage energyStorage;
@@ -219,7 +217,7 @@ public abstract class GeneratorBlockEntity extends AbstractMachineBlockEntity {
 	}
 
 	protected int getEjectingExtractEnergy() {
-		return this.getMaxGeneration();
+		return this.getGeneratingEnergyStorage().getEnergyStored();
 	}
 
 	protected List<Direction> getEjectDirections() {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
@@ -33,8 +33,8 @@ public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity 
 
 	public static final int DEFAULT_ENERGY_USAGE = 1;
 	public static final int DEFAULT_ENERGY_USAGE_PER_RANGE = 0;
-    public static final int DEFAULT_RANGE_MIN = 1;
-    public static final int DEFAULT_RANGE_MAX = 15;
+	public static final int DEFAULT_RANGE_MIN = 1;
+	public static final int DEFAULT_RANGE_MAX = 15;
 	public static final String KEY_TIMER = "timer";
 	public static final String KEY_RANGE = "range";
 	public static final String KEY_WORKINGAREA_VISIBLE = "workingAreaVisible";
@@ -71,22 +71,22 @@ public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity 
 	@Override
 	protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
 		super.createEnergyStorages(registry);
-        int capacity = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY.get();
-        int maxTransfer = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER.get();
-        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
+		int capacity = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY.get();
+		int maxTransfer = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER.get();
+		registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
 	}
-	
+
 	@Override
 	protected int getInitialTankCapacity(ResourceLocation name) {
-        if (name.equals(this.getInputTankName())) {
-            return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY.get();
-        } else if (name.equals(this.getOutputTankName())) {
-            return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY.get();
-        } else {
-            return super.getInitialTankCapacity(name);
-        }
-    }
-	
+		if (name.equals(this.getInputTankName())) {
+			return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY.get();
+		} else if (name.equals(this.getOutputTankName())) {
+			return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY.get();
+		} else {
+			return super.getInitialTankCapacity(name);
+		}
+	}
+
 	@Override
 	public int getTransferPerTick() {
 	    return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER.get();

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
@@ -31,7 +31,7 @@ import net.mrscauthd.beyond_earth.registries.EffectsRegistry;
 
 public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity {
 
-	public static final int DEFAULT_ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_USAGE = 1;
 	public static final String KEY_TIMER = "timer";
 	public static final String KEY_RANGE = "range";
 	public static final String KEY_WORKINGAREA_VISIBLE = "workingAreaVisible";

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Mob;
@@ -73,6 +74,22 @@ public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity 
         int capacity = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY.get();
         int maxTransfer = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER.get();
         registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
+	}
+	
+	@Override
+	protected int getInitialTankCapacity(ResourceLocation name) {
+        if (name.equals(this.getInputTankName())) {
+            return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_FLUID_CAPACITY.get();
+        } else if (name.equals(this.getOutputTankName())) {
+            return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_OXYGEN_CAPACITY.get();
+        } else {
+            return super.getInitialTankCapacity(name);
+        }
+    }
+	
+	@Override
+	public int getTransferPerTick() {
+	    return Config.OXYGEN_BUBBLE_DISTRIBUTOR_TANK_TRANSFER.get();
 	}
 
 	protected void tickProcessing() {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
@@ -32,12 +32,12 @@ import net.mrscauthd.beyond_earth.registries.EffectsRegistry;
 public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity {
 
 	public static final int DEFAULT_ENERGY_USAGE = 1;
+	public static final int DEFAULT_ENERGY_USAGE_PER_RANGE = 0;
+    public static final int DEFAULT_RANGE_MIN = 1;
+    public static final int DEFAULT_RANGE_MAX = 15;
 	public static final String KEY_TIMER = "timer";
 	public static final String KEY_RANGE = "range";
 	public static final String KEY_WORKINGAREA_VISIBLE = "workingAreaVisible";
-
-	public static final int RANGE_MAX = 15;
-	public static final int RANGE_MIN = 1;
 
 	/**
 	 * Interval Ticks, 4 = every 4 ticks
@@ -167,11 +167,11 @@ public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity 
 	}
 
 	public int getRange() {
-		return Math.max(this.getTileData().getInt(KEY_RANGE), RANGE_MIN);
+		return Math.max(this.getTileData().getInt(KEY_RANGE), Config.OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MIN.get());
 	}
 
 	public void setRange(int range) {
-		range = Math.min(Math.max(range, RANGE_MIN), RANGE_MAX);
+		range = Math.min(Math.max(range, Config.OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MIN.get()), Config.OXYGEN_BUBBLE_DISTRIBUTOR_RANGE_MAX.get());
 
 		if (this.getRange() != range) {
 			this.getTileData().putInt(KEY_RANGE, range);

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenBubbleDistributorBlockEntity.java
@@ -18,7 +18,9 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.network.NetworkEvent;
+import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
 import net.mrscauthd.beyond_earth.capabilities.oxygen.IOxygenStorage;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeType;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeTypes;
 import net.mrscauthd.beyond_earth.crafting.OxygenMakingRecipeAbstract;
@@ -28,7 +30,7 @@ import net.mrscauthd.beyond_earth.registries.EffectsRegistry;
 
 public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity {
 
-	public static final int ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_PER_TICK = 1;
 	public static final String KEY_TIMER = "timer";
 	public static final String KEY_RANGE = "range";
 	public static final String KEY_WORKINGAREA_VISIBLE = "workingAreaVisible";
@@ -68,7 +70,9 @@ public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity 
 	@Override
 	protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
 		super.createEnergyStorages(registry);
-		registry.put(this.createEnergyStorageCommon());
+        int capacity = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_CAPACITY.get();
+        int maxTransfer = Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_TRANSFER.get();
+        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
 	}
 
 	protected void tickProcessing() {
@@ -190,7 +194,7 @@ public class OxygenBubbleDistributorBlockEntity extends OxygenMakingBlockEntity 
 	}
 
 	public int getBasePowerForOperation() {
-		return ENERGY_PER_TICK;
+		return Config.OXYGEN_BUBBLE_DISTRIBUTOR_ENERGY_USAGE.get();
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
@@ -78,27 +78,27 @@ public class OxygenLoaderBlockEntity extends OxygenMakingBlockEntity {
 
 	@Override
 	protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
-        super.createEnergyStorages(registry);
-        int capacity = Config.OXYGEN_LOADER_ENERGY_CAPACITY.get();
-        int maxTransfer = Config.OXYGEN_LOADER_ENERGY_TRANSFER.get();
-        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
-    }
+		super.createEnergyStorages(registry);
+		int capacity = Config.OXYGEN_LOADER_ENERGY_CAPACITY.get();
+		int maxTransfer = Config.OXYGEN_LOADER_ENERGY_TRANSFER.get();
+		registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
+	}
 
-    @Override
-    protected int getInitialTankCapacity(ResourceLocation name) {
-        if (name.equals(this.getInputTankName())) {
-            return Config.OXYGEN_LOADER_TANK_FLUID_CAPACITY.get();
-        } else if (name.equals(this.getOutputTankName())) {
-            return Config.OXYGEN_LOADER_TANK_OXYGEN_CAPACITY.get();
-        } else {
-            return super.getInitialTankCapacity(name);
-        }
-    }
-    
-    @Override
-    public int getTransferPerTick() {
-        return Config.OXYGEN_LOADER_TANK_TRANSFER.get();
-    }
+	@Override
+	protected int getInitialTankCapacity(ResourceLocation name) {
+		if (name.equals(this.getInputTankName())) {
+			return Config.OXYGEN_LOADER_TANK_FLUID_CAPACITY.get();
+		} else if (name.equals(this.getOutputTankName())) {
+			return Config.OXYGEN_LOADER_TANK_OXYGEN_CAPACITY.get();
+		} else {
+			return super.getInitialTankCapacity(name);
+		}
+	}
+
+	@Override
+	public int getTransferPerTick() {
+		return Config.OXYGEN_LOADER_TANK_TRANSFER.get();
+	}
 
 	@Override
 	protected void createPowerSystems(PowerSystemRegistry map) {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
@@ -84,6 +84,22 @@ public class OxygenLoaderBlockEntity extends OxygenMakingBlockEntity {
         registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
     }
 
+    @Override
+    protected int getInitialTankCapacity(ResourceLocation name) {
+        if (name.equals(this.getInputTankName())) {
+            return Config.OXYGEN_LOADER_TANK_FLUID_CAPACITY.get();
+        } else if (name.equals(this.getOutputTankName())) {
+            return Config.OXYGEN_LOADER_TANK_OXYGEN_CAPACITY.get();
+        } else {
+            return super.getInitialTankCapacity(name);
+        }
+    }
+    
+    @Override
+    public int getTransferPerTick() {
+        return Config.OXYGEN_LOADER_TANK_TRANSFER.get();
+    }
+
 	@Override
 	protected void createPowerSystems(PowerSystemRegistry map) {
 		super.createPowerSystems(map);

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
@@ -22,7 +22,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class OxygenLoaderBlockEntity extends OxygenMakingBlockEntity {
 
-	public static final int DEFAULT_ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_USAGE = 1;
 	public static final int SLOT_OUTPUT_SINK = 2;
 	public static final int SLOT_OUTPUT_SOURCE = 3;
 

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenLoaderBlockEntity.java
@@ -10,8 +10,10 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.energy.IEnergyStorage;
+import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
 import net.mrscauthd.beyond_earth.capabilities.oxygen.IOxygenStorage;
 import net.mrscauthd.beyond_earth.capabilities.oxygen.OxygenUtil;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeType;
 import net.mrscauthd.beyond_earth.crafting.BeyondEarthRecipeTypes;
 import net.mrscauthd.beyond_earth.crafting.OxygenMakingRecipeAbstract;
@@ -20,7 +22,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class OxygenLoaderBlockEntity extends OxygenMakingBlockEntity {
 
-	public static final int ENERGY_PER_TICK = 1;
+	public static final int DEFAULT_ENERGY_PER_TICK = 1;
 	public static final int SLOT_OUTPUT_SINK = 2;
 	public static final int SLOT_OUTPUT_SOURCE = 3;
 
@@ -76,9 +78,11 @@ public class OxygenLoaderBlockEntity extends OxygenMakingBlockEntity {
 
 	@Override
 	protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
-		super.createEnergyStorages(registry);
-		registry.put(this.createEnergyStorageCommon());
-	}
+        super.createEnergyStorages(registry);
+        int capacity = Config.OXYGEN_LOADER_ENERGY_CAPACITY.get();
+        int maxTransfer = Config.OXYGEN_LOADER_ENERGY_TRANSFER.get();
+        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
+    }
 
 	@Override
 	protected void createPowerSystems(PowerSystemRegistry map) {
@@ -93,7 +97,7 @@ public class OxygenLoaderBlockEntity extends OxygenMakingBlockEntity {
 	}
 
 	public int getBasePowerForOperation() {
-		return ENERGY_PER_TICK;
+		return Config.OXYGEN_LOADER_ENERGY_USAGE.get();
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenMakingBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/OxygenMakingBlockEntity.java
@@ -32,8 +32,6 @@ import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
 import net.mrscauthd.beyond_earth.inventory.StackCacher;
 
 public abstract class OxygenMakingBlockEntity extends AbstractMachineBlockEntity {
-	public static final int TANK_CAPACITY = 3000;
-	public static final int TRANSFER_PER_TICK = 256;
 	public static final ResourceLocation TANK_INPUT = new ResourceLocation(BeyondEarthMod.MODID, "input");
 	public static final ResourceLocation TANK_OUTPUT = new ResourceLocation(BeyondEarthMod.MODID, "output");
 	public static final int SLOT_INPUT_SOURCE = 0;
@@ -85,7 +83,7 @@ public abstract class OxygenMakingBlockEntity extends AbstractMachineBlockEntity
 	}
 
 	protected int getInitialTankCapacity(ResourceLocation name) {
-		return TANK_CAPACITY;
+		return DEFAULT_TANK_CAPACITY;
 	}
 
 	protected FluidTank creatFluidTank(ResourceLocation name) {
@@ -280,7 +278,7 @@ public abstract class OxygenMakingBlockEntity extends AbstractMachineBlockEntity
 	}
 
 	public int getTransferPerTick() {
-		return TRANSFER_PER_TICK;
+		return DEFAULT_TANK_TRANSFER;
 	}
 
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/SolarPanelBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/SolarPanelBlockEntity.java
@@ -7,17 +7,17 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.level.BlockAndTintGetter;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraftforge.energy.IEnergyStorage;
+import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.guis.screens.solarpanel.SolarPanelGui;
 import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class SolarPanelBlockEntity extends GeneratorBlockEntity {
 
-	public static final int ENERGY_PER_TICK = 5;
+	public static final int DEFAULT_ENERGY_PER_TICK = 5;
 
 	public SolarPanelBlockEntity(BlockPos pos, BlockState state) {
 		super(BlockEntitiesRegistry.SOLAR_PANEL_BLOCK_ENTITY.get(), pos, state);
@@ -34,7 +34,7 @@ public class SolarPanelBlockEntity extends GeneratorBlockEntity {
 
 	@Override
 	public int getMaxGeneration() {
-		return ENERGY_PER_TICK;
+		return Config.SOLAR_PANEL_ENERGY_GENERATION.get();
 	}
 
 	@Override
@@ -56,4 +56,12 @@ public class SolarPanelBlockEntity extends GeneratorBlockEntity {
 		list.addAll(Arrays.stream(Direction.values()).filter(d -> d != Direction.UP).toList());
 		return list;
 	}
+
+	@Override
+	protected IEnergyStorage createGeneratingEnergyStorage() {
+        int capacity = Config.SOLAR_PANEL_ENERGY_CAPACITY.get();
+        int maxTransfer = Config.SOLAR_PANEL_ENERGY_TRANSFER.get();
+        return new EnergyStorageBasic(this, capacity, maxTransfer, capacity);
+	}
+
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/SolarPanelBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/SolarPanelBlockEntity.java
@@ -59,9 +59,9 @@ public class SolarPanelBlockEntity extends GeneratorBlockEntity {
 
 	@Override
 	protected IEnergyStorage createGeneratingEnergyStorage() {
-        int capacity = Config.SOLAR_PANEL_ENERGY_CAPACITY.get();
-        int maxTransfer = Config.SOLAR_PANEL_ENERGY_TRANSFER.get();
-        return new EnergyStorageBasic(this, capacity, maxTransfer, capacity);
+		int capacity = Config.SOLAR_PANEL_ENERGY_CAPACITY.get();
+		int maxTransfer = Config.SOLAR_PANEL_ENERGY_TRANSFER.get();
+		return new EnergyStorageBasic(this, capacity, maxTransfer, capacity);
 	}
 
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/SolarPanelBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/SolarPanelBlockEntity.java
@@ -17,7 +17,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class SolarPanelBlockEntity extends GeneratorBlockEntity {
 
-	public static final int DEFAULT_ENERGY_PER_TICK = 5;
+	public static final int DEFAULT_ENERGY_USAGE = 5;
 
 	public SolarPanelBlockEntity(BlockPos pos, BlockState state) {
 		super(BlockEntitiesRegistry.SOLAR_PANEL_BLOCK_ENTITY.get(), pos, state);

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
@@ -21,13 +21,16 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.templates.FluidTank;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
+import net.mrscauthd.beyond_earth.capabilities.energy.EnergyStorageBasic;
 import net.mrscauthd.beyond_earth.capabilities.fluid.FluidHandlerWrapper;
+import net.mrscauthd.beyond_earth.config.Config;
 import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
 import net.mrscauthd.beyond_earth.guis.screens.waterpump.WaterPumpGui;
 import net.mrscauthd.beyond_earth.machines.WaterPump;
 import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
+    public static final int DEFAULT_ENERGY_PER_TICK = 1;
 	public static final int TRANSFER_PER_TICK = 10;
 	
     public WaterPumpBlockEntity(BlockPos pos, BlockState state) {
@@ -140,11 +143,13 @@ public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
     @Override
     protected void createEnergyStorages(NamedComponentRegistry<IEnergyStorage> registry) {
         super.createEnergyStorages(registry);
-        registry.put(this.createEnergyStorageCommon());
+        int capacity = Config.WATER_PUMP_ENERGY_CAPACITY.get();
+        int maxTransfer = Config.WATER_PUMP_ENERGY_TRANSFER.get();
+        registry.put(new EnergyStorageBasic(this, capacity, maxTransfer, capacity));
     }
 
     public int getBasePowerForOperation() {
-        return 1;
+        return Config.WATER_PUMP_ENERGY_USAGE.get();
     }
 
     @Override

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
@@ -30,7 +30,7 @@ import net.mrscauthd.beyond_earth.machines.WaterPump;
 import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
-    public static final int DEFAULT_ENERGY_PER_TICK = 1;
+    public static final int DEFAULT_ENERGY_USAGE = 1;
 	public static final int DEFAULT_TANK_TRANSFER = 10;
 	
     public WaterPumpBlockEntity(BlockPos pos, BlockState state) {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
@@ -31,14 +31,14 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 
 public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
     public static final int DEFAULT_ENERGY_PER_TICK = 1;
-	public static final int TRANSFER_PER_TICK = 10;
+	public static final int DEFAULT_TANK_TRANSFER = 10;
 	
     public WaterPumpBlockEntity(BlockPos pos, BlockState state) {
         super(BlockEntitiesRegistry.WATER_PUMP_BLOCK_ENTITY.get(), pos, state);
     }
 
     public static final ResourceLocation WATER_TANK = new ResourceLocation(BeyondEarthMod.MODID, "water_tank");
-    public static final int TANK_CAPACITY = 6000;
+    public static final int DEFAULT_TANK_CAPACITY = 6000;
     public double WATER_TIMER = 0;
     private FluidTank waterTank;
 
@@ -93,7 +93,7 @@ public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
     }
     
     public int getTransferPerTick() {
-		return TRANSFER_PER_TICK;
+		return Config.WATER_PUMP_TANK_TRANSFER.get();
 	}
 
     public boolean hasSpaceInWaterTank(int water) {
@@ -101,7 +101,7 @@ public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
     }
 
     public boolean hasSpaceIn(int water, FluidStack storage) {
-        return water < TANK_CAPACITY - 999;
+        return water < this.getWaterTank().getCapacity() - 999;
     }
 
     @Override
@@ -159,7 +159,7 @@ public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
     }
 
     protected int getInitialTankCapacity(ResourceLocation name) {
-        return TANK_CAPACITY;
+        return Config.WATER_PUMP_TANK_CAPACITY.get();
     }
 
     protected Predicate<FluidStack> getInitialTankValidator(ResourceLocation name) {

--- a/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/machines/tile/WaterPumpBlockEntity.java
@@ -32,6 +32,7 @@ import net.mrscauthd.beyond_earth.registries.BlockEntitiesRegistry;
 public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
     public static final int DEFAULT_ENERGY_USAGE = 1;
 	public static final int DEFAULT_TANK_TRANSFER = 10;
+	public static final int DEFAULT_WORK_INTERVAL = 10;
 	
     public WaterPumpBlockEntity(BlockPos pos, BlockState state) {
         super(BlockEntitiesRegistry.WATER_PUMP_BLOCK_ENTITY.get(), pos, state);
@@ -61,7 +62,7 @@ public class WaterPumpBlockEntity extends AbstractMachineBlockEntity {
 
                     WATER_TIMER = WATER_TIMER + 1;
 
-                    if (WATER_TIMER > 10) {
+                    if (WATER_TIMER > Config.WATER_PUMP_WORK_INTERVAL.get()) {
 
                         this.level.setBlock(pickupPos, Blocks.AIR.defaultBlockState(), 3);
 


### PR DESCRIPTION
* Relate from #141 
* Add 'Machines' group in config file

# Configurable Values

## Coal Generator

1 Energy Generation per Tick
2. Energy Capacity
3. Energy Transfer Speed

* Only configurable generation per tick
* Remove and Add new 'beyond_earth:coal_generator' recipe what 'burnTime' value changed

## Solar Panel

1 Energy Generation per Tick
2. Energy Capacity
3. Energy Transfer Speed

## Fuel Refinery

1 Energy Usage per Tick
2. Energy Capacity
3. Energy Transfer Speed
4. Fluid Input, Output Tank's Capacity
5. Fluid Tank's Transfer Speed

## Oxygen Bubble Distributor

1 Energy Usage per Tick
2. Energy Capacity
3. Energy Transfer Speed
4. Fluid Input, Oxygen Output Tank's Capacity
5. Fluid/Oxygen Tank's Transfer Speed
6.  Min/Max Range of Working Area

## Oxygen Loader

1 Energy Usage per Tick
2. Energy Capacity
3. Energy Transfer Speed
4. Fluid Input, Oxygen Output Tank's Capacity
5. Fluid/Oxygen Tank's Transfer Speed

## Water Pump

1 Energy Usage per Tick
2. Energy Capacity
3. Energy Transfer Speed
4. Water Tank's Capacity
5. Water Pumping Internal Ticks

