### PR TITLE
Fuel refine using forge:curde_oil

### DIFF
--- a/src/main/resources/data/beyond_earth/recipes/fuel_refining/fuel_from_curde_oil.json
+++ b/src/main/resources/data/beyond_earth/recipes/fuel_refining/fuel_from_curde_oil.json
@@ -1,7 +1,7 @@
 {
    "type":"beyond_earth:fuel_refinery",
    "input":{
-      "tag":"beyond_earth:oil",
+      "tag":"forge:crude_oil",
       "amount":2
    },
    "output":{


### PR DESCRIPTION
This pr will add compatibility to refining 'forge:crude oil' tagged fluids

![image](https://user-images.githubusercontent.com/44163945/184873770-a7ce045e-08e3-4db8-9da1-533d71ffd4fa.png)
