### PR TITLE
Add IFuelVehicle interface

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/entities/IFuelRocketEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/IFuelRocketEntity.java
@@ -1,0 +1,109 @@
+package net.mrscauthd.beyond_earth.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.mrscauthd.beyond_earth.events.Methods;
+import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
+import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
+import net.mrscauthd.beyond_earth.gauge.GaugeValueSimple;
+import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
+import net.mrscauthd.beyond_earth.registries.TagsRegistry;
+
+public abstract class IFuelRocketEntity extends IRocketEntity implements IFuelVehicleEntity {
+
+	public IFuelRocketEntity(EntityType<?> p_19870_, Level p_19871_) {
+		super(p_19870_, p_19871_);
+	}
+
+	@Override
+	public void tick() {
+		super.tick();
+
+		this.fillUpRocket();
+	}
+
+	public void fillUpRocket() {
+		if (Methods.tagCheck(FluidUtil2.findBucketFluid(this.getInventory().getStackInSlot(0).getItem()), TagsRegistry.FLUID_VEHICLE_FUEL_TAG) && this.canPutFuelMuchAsBucket()) {
+
+			if (this.getFuel() == this.getBuckets() * this.getFuelOfBucket()) {
+				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
+				this.putFuelMuchAsBucket();
+			}
+		}
+
+		int fillUpInto = this.getBuckets() * this.getFuelOfBucket();
+
+		if (this.getFuel() < fillUpInto) {
+			this.setFuel(Math.min(this.getFuel() + this.getFillUpSpeed(), fillUpInto));
+		}
+	}
+
+	@Override
+	public boolean canStart() {
+		return this.getFuel() >= this.getFuelCapacity();
+	}
+
+	@Override
+	public void sendCantStartMessage(Player player) {
+		Methods.noFuelMessage(player);
+	}
+
+	@Override
+	public List<IGaugeValue> getGaugeValues() {
+		List<IGaugeValue> list = new ArrayList<>();
+		int fuel = this.getFuel();
+		int capacity = this.getFuelCapacity();
+		list.add(new GaugeValueSimple(GaugeValueHelper.FUEL_NAME, (int) Math.round(fuel / (capacity / 100.0D)), 100, (Component) null, "%").color(GaugeValueHelper.FUEL_COLOR));
+		return list;
+	}
+
+	@Override
+	public int getFuel() {
+		return this.getEntityData().get(FUEL);
+	}
+
+	@Override
+	public void setFuel(int fuel) {
+		this.getEntityData().set(FUEL, Mth.clamp(fuel, 0, this.getFuelCapacity()));
+	}
+	
+	@Override
+	public int getFuelCapacity() {
+		return this.getRequiredFuelBuckets() * this.getFuelOfBucket();
+	}
+
+	protected int getBuckets() {
+		return this.getEntityData().get(BUCKETS);
+	}
+
+	public void setBucket(int bucket) {
+		this.getEntityData().set(BUCKETS, Mth.clamp(bucket, 0, this.getRequiredFuelBuckets()));
+	}
+
+	public abstract int getRequiredFuelBuckets();
+
+	public abstract int getFuelOfBucket();
+
+	@Override
+	public void putFuelMuchAsBucket() {
+		this.setBucket(this.getBuckets() + 1);
+	}
+
+	@Override
+	public boolean canPutFuelMuchAsBucket() {
+		return (this.getBuckets() + 1) <= this.getRequiredFuelBuckets();
+	}
+
+	protected int getFillUpSpeed() {
+		return 1;
+	}
+
+}

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/IFuelVehicleEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/IFuelVehicleEntity.java
@@ -1,0 +1,22 @@
+package net.mrscauthd.beyond_earth.entities;
+
+import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
+import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
+
+public interface IFuelVehicleEntity {
+	public int getFuel();
+
+	public void setFuel(int fuel);
+
+	public int getFuelCapacity();
+
+	public void putFuelMuchAsBucket();
+
+	public boolean canPutFuelMuchAsBucket();
+
+	public default IGaugeValue getFuelGauge() {
+		int fuel = this.getFuel();
+		int capacity = this.getFuelCapacity();
+		return GaugeValueHelper.getFuel(fuel, capacity);
+	}
+}

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/IFuelVehicleEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/IFuelVehicleEntity.java
@@ -2,8 +2,9 @@ package net.mrscauthd.beyond_earth.entities;
 
 import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
 import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
+import net.mrscauthd.beyond_earth.gauge.IGaugeValuesProvider;
 
-public interface IFuelVehicleEntity {
+public interface IFuelVehicleEntity extends IGaugeValuesProvider {
 	public int getFuel();
 
 	public void setFuel(int fuel);

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/IRocketEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/IRocketEntity.java
@@ -176,8 +176,6 @@ public abstract class IRocketEntity extends VehicleEntity {
 
     public abstract void particleSpawn();
 
-    public abstract void fillUpRocket();
-
     public boolean doesDrop(BlockState state, BlockPos pos) {
         if (this.isOnGround() || this.isInWater()) {
 
@@ -309,7 +307,6 @@ public abstract class IRocketEntity extends VehicleEntity {
         super.tick();
 
         this.checkOnBlocks();
-        this.fillUpRocket();
         this.rocketExplosion();
         this.burnEntities();
 
@@ -356,4 +353,8 @@ public abstract class IRocketEntity extends VehicleEntity {
 
         return new Vec3(this.getX(), this.getBoundingBox().maxY, this.getZ());
     }
+
+    public abstract boolean canStart();
+
+    public abstract void sendCantStartMessage(Player player);
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier1Entity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier1Entity.java
@@ -17,23 +17,23 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.network.NetworkHooks;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
-import net.mrscauthd.beyond_earth.events.Methods;
 import net.mrscauthd.beyond_earth.events.forge.RocketPickResultEvent;
-import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
 
 import net.mrscauthd.beyond_earth.guis.screens.rocket.RocketGui;
+import net.mrscauthd.beyond_earth.items.IFuelRocketItem;
 import net.mrscauthd.beyond_earth.registries.ItemsRegistry;
 import net.mrscauthd.beyond_earth.registries.ParticlesRegistry;
-import net.mrscauthd.beyond_earth.registries.TagsRegistry;
 
-public class RocketTier1Entity extends IRocketEntity {
+public class RocketTier1Entity extends IFuelRocketEntity {
+
+	public static final int FUEL_OF_BUCKET = 300;
+	public static final int FUEL_BUCKETS = 1;
 
 	public RocketTier1Entity(EntityType type, Level world) {
 		super(type, world);
@@ -48,8 +48,8 @@ public class RocketTier1Entity extends IRocketEntity {
 	@Override
 	public ItemStack getPickedResult(HitResult target) {
 		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_1_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.fuelTag, this.getFuel());
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.bucketTag, this.getBuckets());
 		MinecraftForge.EVENT_BUS.post(new RocketPickResultEvent(this, itemStack));
 
 		return itemStack;
@@ -57,10 +57,7 @@ public class RocketTier1Entity extends IRocketEntity {
 
 	@Override
 	protected void spawnRocketItem() {
-		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_1_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
-
+		ItemStack itemStack = this.getPickedResult(null);
 		ItemEntity entityToSpawn = new ItemEntity(level, this.getX(), this.getY(), this.getZ(), itemStack);
 		entityToSpawn.setPickUpDelay(10);
 		level.addFreshEntity(entityToSpawn);
@@ -118,14 +115,12 @@ public class RocketTier1Entity extends IRocketEntity {
 	}
 
 	@Override
-	public void fillUpRocket() {
-		if (Methods.tagCheck(FluidUtil2.findBucketFluid(this.getInventory().getStackInSlot(0).getItem()), TagsRegistry.FLUID_VEHICLE_FUEL_TAG) && this.entityData.get(BUCKETS) != 1) {
-			this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-			this.getEntityData().set(BUCKETS, 1);
-		}
+	public int getFuelOfBucket() {
+		return FUEL_OF_BUCKET;
+	}
 
-		if (this.getEntityData().get(BUCKETS) == 1 && this.getEntityData().get(FUEL) < 300) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		}
+	@Override
+	public int getRequiredFuelBuckets() {
+		return FUEL_BUCKETS;
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier2Entity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier2Entity.java
@@ -16,7 +16,6 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
@@ -24,15 +23,16 @@ import net.minecraftforge.network.NetworkHooks;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
 
 import io.netty.buffer.Unpooled;
-import net.mrscauthd.beyond_earth.events.Methods;
 import net.mrscauthd.beyond_earth.events.forge.RocketPickResultEvent;
-import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
 import net.mrscauthd.beyond_earth.guis.screens.rocket.RocketGui;
+import net.mrscauthd.beyond_earth.items.IFuelRocketItem;
 import net.mrscauthd.beyond_earth.registries.ItemsRegistry;
 import net.mrscauthd.beyond_earth.registries.ParticlesRegistry;
-import net.mrscauthd.beyond_earth.registries.TagsRegistry;
 
-public class RocketTier2Entity extends IRocketEntity {
+public class RocketTier2Entity extends IFuelRocketEntity {
+
+	public static final int FUEL_OF_BUCKET = 100;
+	public static final int FUEL_BUCKETS = 3;
 
 	public RocketTier2Entity(EntityType type, Level world) {
 		super(type, world);
@@ -47,8 +47,8 @@ public class RocketTier2Entity extends IRocketEntity {
 	@Override
 	public ItemStack getPickResult() {
 		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_2_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.fuelTag, this.getFuel());
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.bucketTag, this.getBuckets());
 		MinecraftForge.EVENT_BUS.post(new RocketPickResultEvent(this, itemStack));
 
 		return itemStack;
@@ -56,10 +56,7 @@ public class RocketTier2Entity extends IRocketEntity {
 
 	@Override
 	protected void spawnRocketItem() {
-		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_2_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
-
+		ItemStack itemStack = this.getPickedResult(null);
 		ItemEntity entityToSpawn = new ItemEntity(level, this.getX(), this.getY(), this.getZ(), itemStack);
 		entityToSpawn.setPickUpDelay(10);
 		level.addFreshEntity(entityToSpawn);
@@ -117,27 +114,12 @@ public class RocketTier2Entity extends IRocketEntity {
 	}
 
 	@Override
-	public void fillUpRocket() {
-		if (Methods.tagCheck(FluidUtil2.findBucketFluid(this.getInventory().getStackInSlot(0).getItem()), TagsRegistry.FLUID_VEHICLE_FUEL_TAG) && this.entityData.get(BUCKETS) < 3) {
+	public int getFuelOfBucket() {
+		return FUEL_OF_BUCKET;
+	}
 
-			if (this.entityData.get(FUEL) == 0 && this.entityData.get(BUCKETS) == 0) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			} else if (this.getEntityData().get(FUEL) == 100 && this.getEntityData().get(BUCKETS) == 1) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			} else if (this.getEntityData().get(FUEL) == 200 && this.getEntityData().get(BUCKETS) == 2) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			}
-		}
-
-		if (this.getEntityData().get(BUCKETS) == 1 && this.getEntityData().get(FUEL) < 100) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		} else if (this.getEntityData().get(BUCKETS) == 2 && this.getEntityData().get(FUEL) < 200) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		} else if (this.getEntityData().get(BUCKETS) == 3 && this.getEntityData().get(FUEL) < 300) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		}
+	@Override
+	public int getRequiredFuelBuckets() {
+		return FUEL_BUCKETS;
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier3Entity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier3Entity.java
@@ -16,7 +16,6 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
@@ -24,15 +23,16 @@ import net.minecraftforge.network.NetworkHooks;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
 
 import io.netty.buffer.Unpooled;
-import net.mrscauthd.beyond_earth.events.Methods;
 import net.mrscauthd.beyond_earth.events.forge.RocketPickResultEvent;
-import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
 import net.mrscauthd.beyond_earth.guis.screens.rocket.RocketGui;
+import net.mrscauthd.beyond_earth.items.IFuelRocketItem;
 import net.mrscauthd.beyond_earth.registries.ItemsRegistry;
 import net.mrscauthd.beyond_earth.registries.ParticlesRegistry;
-import net.mrscauthd.beyond_earth.registries.TagsRegistry;
 
-public class RocketTier3Entity extends IRocketEntity {
+public class RocketTier3Entity extends IFuelRocketEntity {
+
+	public static final int FUEL_OF_BUCKET = 100;
+	public static final int FUEL_BUCKETS = 3;
 
 	public RocketTier3Entity(EntityType type, Level world) {
 		super(type, world);
@@ -47,8 +47,8 @@ public class RocketTier3Entity extends IRocketEntity {
 	@Override
 	public ItemStack getPickResult() {
 		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_3_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.fuelTag, this.getFuel());
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.bucketTag, this.getBuckets());
 		MinecraftForge.EVENT_BUS.post(new RocketPickResultEvent(this, itemStack));
 
 		return itemStack;
@@ -56,10 +56,7 @@ public class RocketTier3Entity extends IRocketEntity {
 
 	@Override
 	protected void spawnRocketItem() {
-		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_3_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
-
+		ItemStack itemStack = this.getPickedResult(null);
 		ItemEntity entityToSpawn = new ItemEntity(level, this.getX(), this.getY(), this.getZ(), itemStack);
 		entityToSpawn.setPickUpDelay(10);
 		level.addFreshEntity(entityToSpawn);
@@ -117,27 +114,12 @@ public class RocketTier3Entity extends IRocketEntity {
 	}
 
 	@Override
-	public void fillUpRocket() {
-		if (Methods.tagCheck(FluidUtil2.findBucketFluid(this.getInventory().getStackInSlot(0).getItem()), TagsRegistry.FLUID_VEHICLE_FUEL_TAG) && this.entityData.get(BUCKETS) < 3) {
+	public int getFuelOfBucket() {
+		return FUEL_OF_BUCKET;
+	}
 
-			if (this.entityData.get(FUEL) == 0 && this.entityData.get(BUCKETS) == 0) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			} else if (this.getEntityData().get(FUEL) == 100 && this.getEntityData().get(BUCKETS) == 1) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			} else if (this.getEntityData().get(FUEL) == 200 && this.getEntityData().get(BUCKETS) == 2) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			}
-		}
-
-		if (this.getEntityData().get(BUCKETS) == 1 && this.getEntityData().get(FUEL) < 100) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		} else if (this.getEntityData().get(BUCKETS) == 2 && this.getEntityData().get(FUEL) < 200) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		} else if (this.getEntityData().get(BUCKETS) == 3 && this.getEntityData().get(FUEL) < 300) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		}
+	@Override
+	public int getRequiredFuelBuckets() {
+		return FUEL_BUCKETS;
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier4Entity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/RocketTier4Entity.java
@@ -12,27 +12,27 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
-import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.network.NetworkHooks;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
-import net.mrscauthd.beyond_earth.events.Methods;
 import net.mrscauthd.beyond_earth.events.forge.RocketPickResultEvent;
-import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
 import net.mrscauthd.beyond_earth.guis.screens.rocket.RocketGui;
+import net.mrscauthd.beyond_earth.items.IFuelRocketItem;
 import net.mrscauthd.beyond_earth.registries.ItemsRegistry;
 import net.mrscauthd.beyond_earth.registries.ParticlesRegistry;
-import net.mrscauthd.beyond_earth.registries.TagsRegistry;
 
-public class RocketTier4Entity extends IRocketEntity {
+public class RocketTier4Entity extends IFuelRocketEntity {
+
+	public static final int FUEL_OF_BUCKET = 100;
+	public static final int FUEL_BUCKETS = 3;
 
 	public RocketTier4Entity(EntityType type, Level world) {
 		super(type, world);
@@ -47,8 +47,8 @@ public class RocketTier4Entity extends IRocketEntity {
 	@Override
 	public ItemStack getPickResult() {
 		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_4_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.fuelTag, this.getFuel());
+		itemStack.getOrCreateTag().putInt(IFuelRocketItem.bucketTag, this.getBuckets());
 		MinecraftForge.EVENT_BUS.post(new RocketPickResultEvent(this, itemStack));
 
 		return itemStack;
@@ -56,10 +56,7 @@ public class RocketTier4Entity extends IRocketEntity {
 
 	@Override
 	protected void spawnRocketItem() {
-		ItemStack itemStack = new ItemStack(ItemsRegistry.TIER_4_ROCKET_ITEM.get(), 1);
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getEntityData().get(FUEL));
-		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":buckets", this.getEntityData().get(BUCKETS));
-
+		ItemStack itemStack = this.getPickedResult(null);
 		ItemEntity entityToSpawn = new ItemEntity(level, this.getX(), this.getY(), this.getZ(), itemStack);
 		entityToSpawn.setPickUpDelay(10);
 		level.addFreshEntity(entityToSpawn);
@@ -126,27 +123,12 @@ public class RocketTier4Entity extends IRocketEntity {
 	}
 
 	@Override
-	public void fillUpRocket() {
-		if (Methods.tagCheck(FluidUtil2.findBucketFluid(this.getInventory().getStackInSlot(0).getItem()), TagsRegistry.FLUID_VEHICLE_FUEL_TAG) && this.entityData.get(BUCKETS) < 3) {
+	public int getFuelOfBucket() {
+		return FUEL_OF_BUCKET;
+	}
 
-			if (this.entityData.get(FUEL) == 0 && this.entityData.get(BUCKETS) == 0) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			} else if (this.getEntityData().get(FUEL) == 100 && this.getEntityData().get(BUCKETS) == 1) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			} else if (this.getEntityData().get(FUEL) == 200 && this.getEntityData().get(BUCKETS) == 2) {
-				this.getInventory().setStackInSlot(0, new ItemStack(Items.BUCKET));
-				this.getEntityData().set(BUCKETS, this.getEntityData().get(BUCKETS) + 1);
-			}
-		}
-
-		if (this.getEntityData().get(BUCKETS) == 1 && this.getEntityData().get(FUEL) < 100) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		} else if (this.getEntityData().get(BUCKETS) == 2 && this.getEntityData().get(FUEL) < 200) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		} else if (this.getEntityData().get(BUCKETS) == 3 && this.getEntityData().get(FUEL) < 300) {
-			this.getEntityData().set(FUEL, this.getEntityData().get(FUEL) + 1);
-		}
+	@Override
+	public int getRequiredFuelBuckets() {
+		return FUEL_BUCKETS;
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/entities/RoverEntity.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/entities/RoverEntity.java
@@ -1,6 +1,14 @@
 package net.mrscauthd.beyond_earth.entities;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Sets;
+
 import io.netty.buffer.Unpooled;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -18,7 +26,10 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.animal.FlyingAnimal;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
@@ -44,415 +55,412 @@ import net.minecraftforge.network.NetworkHooks;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
 import net.mrscauthd.beyond_earth.events.Methods;
 import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
+import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
 import net.mrscauthd.beyond_earth.guis.screens.rover.RoverGui;
 import net.mrscauthd.beyond_earth.items.RoverItem;
 import net.mrscauthd.beyond_earth.registries.ItemsRegistry;
 import net.mrscauthd.beyond_earth.registries.TagsRegistry;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Set;
-
 public class RoverEntity extends VehicleEntity implements IFuelVehicleEntity {
-    private double speed = 0;
+	private double speed = 0;
 
-    public float flyingSpeed = 0.02F;
-    public float animationSpeedOld;
-    public float animationSpeed;
-    public float animationPosition;
+	public float flyingSpeed = 0.02F;
+	public float animationSpeedOld;
+	public float animationSpeed;
+	public float animationPosition;
 
-    private float FUEL_USE_TICK = 8;
-    private float FUEL_TIMER = 0;
+	private float FUEL_USE_TICK = 8;
+	private float FUEL_TIMER = 0;
 
-    public static final EntityDataAccessor<Integer> FUEL = SynchedEntityData.defineId(RoverEntity.class, EntityDataSerializers.INT);
+	public static final EntityDataAccessor<Integer> FUEL = SynchedEntityData.defineId(RoverEntity.class, EntityDataSerializers.INT);
 
-    public static final EntityDataAccessor<Boolean> FORWARD = SynchedEntityData.defineId(RoverEntity.class, EntityDataSerializers.BOOLEAN);
+	public static final EntityDataAccessor<Boolean> FORWARD = SynchedEntityData.defineId(RoverEntity.class, EntityDataSerializers.BOOLEAN);
 
 	public static final int FUEL_BUCKETS = 3;
 	public static final int FUEL_CAPACITY = FUEL_BUCKETS * FluidUtil2.BUCKET_SIZE;
 
-    public RoverEntity(EntityType type, Level worldIn) {
-        super(type, worldIn);
-        this.entityData.define(FUEL, 0);
-        this.entityData.define(FORWARD, false);
-    }
-
-    @Override
-    public boolean isPushable() {
-        return false;
-    }
-
-    @Override
-    public boolean canBeCollidedWith() {
-        return false;
-    }
-
-    @Override
-    public void push(Entity p_21294_) {
-    }
-
-    @Deprecated
-    public boolean canBeRiddenInWater() {
-        return true;
-    }
-
-    @Override
-    public boolean rideableUnderWater() {
-        return true;
-    }
-
-    @Override
-    public double getPassengersRidingOffset() {
-        return super.getPassengersRidingOffset() - 0.15;
-    }
-
-    @OnlyIn(Dist.CLIENT)
-    @Override
-    public void onPassengerTurned(Entity p_20320_) {
-        this.applyYawToEntity(p_20320_);
-    }
-
-    @Override
-    public Vec3 getDismountLocationForPassenger(LivingEntity livingEntity) {
-        Vec3[] avector3d = new Vec3[]{getCollisionHorizontalEscapeVector((double)this.getBbWidth(), (double)livingEntity.getBbWidth(), livingEntity.getYRot()), getCollisionHorizontalEscapeVector((double)this.getBbWidth(), (double)livingEntity.getBbWidth(), livingEntity.getYRot() - 22.5F), getCollisionHorizontalEscapeVector((double)this.getBbWidth(), (double)livingEntity.getBbWidth(), livingEntity.getYRot() + 22.5F), getCollisionHorizontalEscapeVector((double)this.getBbWidth(), (double)livingEntity.getBbWidth(), livingEntity.getYRot() - 45.0F), getCollisionHorizontalEscapeVector((double)this.getBbWidth(), (double)livingEntity.getBbWidth(), livingEntity.getYRot() + 45.0F)};
-        Set<BlockPos> set = Sets.newLinkedHashSet();
-        double d0 = this.getBoundingBox().maxY;
-        double d1 = this.getBoundingBox().minY - 0.5D;
-        BlockPos.MutableBlockPos blockpos$mutable = new BlockPos.MutableBlockPos();
-
-        for(Vec3 vector3d : avector3d) {
-            blockpos$mutable.set(this.getX() + vector3d.x, d0, this.getZ() + vector3d.z);
-
-            for(double d2 = d0; d2 > d1; --d2) {
-                set.add(blockpos$mutable.immutable());
-                blockpos$mutable.move(Direction.DOWN);
-            }
-        }
-
-        for(BlockPos blockpos : set) {
-            if (!this.level.getFluidState(blockpos).is(FluidTags.LAVA)) {
-                double d3 = this.level.getBlockFloorHeight(blockpos);
-                if (DismountHelper.isBlockFloorValid(d3)) {
-                    Vec3 vector3d1 = Vec3.upFromBottomCenterOf(blockpos, d3);
-
-                    for(Pose pose : livingEntity.getDismountPoses()) {
-                        AABB axisalignedbb = livingEntity.getLocalBoundsForPose(pose);
-                        if (DismountHelper.isBlockFloorValid(this.level.getBlockFloorHeight(blockpos))) {
-                            livingEntity.setPose(pose);
-                            return vector3d1;
-                        }
-                    }
-                }
-            }
-        }
-
-        return new Vec3(this.getX(), this.getBoundingBox().maxY, this.getZ());
-    }
-
-    protected void applyYawToEntity(Entity entityToUpdate) {
-        entityToUpdate.setYBodyRot(this.getYRot());
-        float f = Mth.wrapDegrees(entityToUpdate.getYRot() - this.getYRot());
-        float f1 = Mth.clamp(f, -105.0F, 105.0F);
-        entityToUpdate.yRotO += f1 - f;
-        entityToUpdate.setYRot(entityToUpdate.getYRot() + f1 - f);
-        entityToUpdate.setYHeadRot(entityToUpdate.getYRot());
-    }
-
-    @Override
-    protected void removePassenger(Entity passenger) {
-        if (passenger.isCrouching() && !passenger.level.isClientSide) {
-            if (passenger instanceof ServerPlayer) {
-                this.setSpeed(0f);
-            }
-        }
-        super.removePassenger(passenger);
-    }
-
-    @Override
-    public ItemStack getPickedResult(HitResult target) {
-        ItemStack itemStack = new ItemStack(ItemsRegistry.ROVER_ITEM.get(), 1);
-        itemStack.getOrCreateTag().putInt(RoverItem.fuelTag, this.getFuel());
-
-        return itemStack;
-    }
-
-    @Override
-    public void kill() {
-        this.spawnRoverItem();
-        this.dropEquipment();
-
-        if (!this.level.isClientSide) {
-            this.remove(RemovalReason.DISCARDED);
-        }
-    }
-
-    @Override
-    public AABB getBoundingBoxForCulling() {
-        return new AABB(this.getX(), this.getY(), this.getZ(), this.getX(), this.getY(), this.getZ()).inflate(4.5,4.5,4.5);
-    }
-
-    @Override
-    public boolean hurt(DamageSource source, float p_21017_) {
-        if (!source.isProjectile() && source.getEntity() != null && source.getEntity().isCrouching() && !this.isVehicle()) {
-            this.spawnRoverItem();
-            this.dropEquipment();
-
-            if (!this.level.isClientSide) {
-                this.remove(RemovalReason.DISCARDED);
-            }
-            return true;
-        }
-
-        return false;
-    }
-
-    protected void spawnRoverItem() {
-        ItemStack itemStack = new ItemStack(ItemsRegistry.ROVER_ITEM.get(), 1);
-        itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getFuel());
-
-        ItemEntity entityToSpawn = new ItemEntity(level, this.getX(), this.getY(), this.getZ(), itemStack);
-        entityToSpawn.setPickUpDelay(10);
-        level.addFreshEntity(entityToSpawn);
-    }
-
-    protected void dropEquipment() {
-        for (int i = 0; i < inventory.getSlots(); ++i) {
-            ItemStack itemstack = inventory.getStackInSlot(i);
-            if (!itemstack.isEmpty() && !EnchantmentHelper.hasVanishingCurse(itemstack)) {
-                this.spawnAtLocation(itemstack);
-            }
-        }
-    }
-
-    private final ItemStackHandler inventory = new ItemStackHandler(9) {
-        @Override
-        public int getSlotLimit(int slot) {
-            return 64;
-        }
-    };
-
-    private final CombinedInvWrapper combined = new CombinedInvWrapper(inventory);
-
-    @Override
-    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction side) {
-        if (this.isAlive() && capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && side == null) {
-            return LazyOptional.of(() -> combined).cast();
-        }
-        return super.getCapability(capability, side);
-    }
-
-    public IItemHandlerModifiable getItemHandler() {
-        return (IItemHandlerModifiable) this.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).resolve().get();
-    }
-
-    @Override
-    public void addAdditionalSaveData(CompoundTag compound) {
-        compound.put("InventoryCustom", inventory.serializeNBT());
-
-        compound.putInt("fuel", this.getFuel());
-        compound.putBoolean("forward", this.getEntityData().get(FORWARD));
-    }
-
-    @Override
-    public void readAdditionalSaveData(CompoundTag compound) {
-        Tag inventoryCustom = compound.get("InventoryCustom");
-        if (inventoryCustom instanceof CompoundTag) {
-            inventory.deserializeNBT((CompoundTag) inventoryCustom);
-        }
-
-        this.setFuel(compound.getInt("fuel"));
-        this.entityData.set(FORWARD, compound.getBoolean("forward"));
-    }
-
-    @Override
-    public InteractionResult interact(Player player, InteractionHand hand) {
-        super.interact(player, hand);
-        InteractionResult result = InteractionResult.sidedSuccess(this.level.isClientSide);
-
-        if (!this.level.isClientSide) {
-            if (player.isCrouching()) {
-                NetworkHooks.openGui((ServerPlayer) player, new MenuProvider() {
-                    @Override
-                    public Component getDisplayName() {
-                        return RoverEntity.this.getDisplayName();
-                    }
-
-                    @Override
-                    public AbstractContainerMenu createMenu(int id, Inventory inventory, Player player) {
-                        FriendlyByteBuf packetBuffer = new FriendlyByteBuf(Unpooled.buffer());
-                        packetBuffer.writeVarInt(RoverEntity.this.getId());
-                        return new RoverGui.GuiContainer(id, inventory, packetBuffer);
-                    }
-                }, buf -> {
-                    buf.writeVarInt(this.getId());
-                });
-
-                return InteractionResult.CONSUME;
-            }
-
-            player.startRiding(this);
-            return InteractionResult.CONSUME;
-        }
-
-        return result;
-    }
-
-    public boolean getforward() {
-        return this.entityData.get(FORWARD);
-    }
-
-    @Override
-    public void tick() {
-        super.tick();
-
-        /** Reset Fall Damage for Passengers too */
-        this.resetFallDistance();
-
-        //Fuel Load up
-        if (Methods.tagCheck(FluidUtil2.findBucketFluid(this.inventory.getStackInSlot(0).getItem()), TagsRegistry.FLUID_VEHICLE_FUEL_TAG)) {
-
-            if (this.canPutFuelMuchAsBucket()) {
-                this.putFuelMuchAsBucket();
-                this.inventory.setStackInSlot(0, new ItemStack(Items.BUCKET));
-            }
-        }
-
-        if (this.getPassengers().isEmpty()) {
-            return;
-        }
-
-        if (!(this.getPassengers().get(0) instanceof Player)) {
-            return;
-        }
-
-        if (this.isEyeInFluid(FluidTags.WATER)) {
-            return;
-        }
-
-        FUEL_TIMER++;
-
-        Player passanger = (Player) this.getPassengers().get(0);
-
-        passanger.resetFallDistance();
-
-        if (passanger.zza > 0.01 && this.getFuel() != 0) {
-
-            if (FUEL_TIMER > FUEL_USE_TICK) {
-                this.setFuel(this.getFuel() - 1);
-                FUEL_TIMER = 0;
-            }
-            this.entityData.set(FORWARD, true);
-        } else if (passanger.zza < -0.01 && this.getFuel() != 0) {
-
-            if (FUEL_TIMER > FUEL_USE_TICK) {
-                this.setFuel(this.getFuel() - 1);
-                FUEL_TIMER = 0;
-            }
-            this.entityData.set(FORWARD, false);
-        }
-    }
-
-    @Override
-    public float getFrictionInfluencedSpeed(float p_21331_) {
-        return this.onGround ? this.getSpeed() * (0.21600002F / (p_21331_ * p_21331_ * p_21331_)) : this.flyingSpeed;
-    }
-
-    @Override
-    public void travel(Vec3 p_21280_) {
-        this.calculateEntityAnimation(this, this instanceof FlyingAnimal);
-
-        if (!this.getPassengers().isEmpty() && this.getPassengers().get(0) instanceof Player) {
-
-            Player passanger = (Player) this.getPassengers().get(0);
-
-            this.flyingSpeed = this.getSpeed() * 0.15F;
-            this.maxUpStep = 1.0F;
-
-            double pmovement = passanger.zza;
-
-            if (pmovement == 0 || this.getFuel() == 0 || this.isEyeInFluid(FluidTags.WATER)) {
-                pmovement = 0;
-                this.setSpeed(0f);
-
-                if (speed != 0 && speed > 0.02) {
-                    speed = speed - 0.02;
-                }
-            }
-
-            if (this.entityData.get(FORWARD) && this.getFuel() != 0) {
-                if (this.getSpeed() >= 0.01) {
-                    if (speed <= 0.32) {
-                        speed = speed + 0.02;
-                    }
-                }
-
-                if (this.getSpeed() < 0.25) {
-                    this.setSpeed(this.getSpeed() + 0.02F);
-                }
-
-            }
-
-            if (!this.entityData.get(FORWARD)) {
-
-                if (this.getFuel() != 0 && !this.isEyeInFluid(FluidTags.WATER)) {
-
-                    if (this.getSpeed() <= 0.04) {
-                        this.setSpeed(this.getSpeed() + 0.02f);
-                    }
-                }
-
-                if (this.getSpeed() >= 0.08) {
-                    this.setSpeed(0f);
-                }
-            }
-
-            if (this.entityData.get(FORWARD)) {
-                this.setWellRotationPlus(4.0f, 0.4f);
-            } else {
-                this.setWellRotationMinus(8.0f, 0.8f);
-            }
-
-            super.travel(new Vec3(0, 0, pmovement));
-            return;
-        }
-
-        super.travel(new Vec3(0, 0, 0));
-    }
-
-    public void setWellRotationMinus(float rotation1, float rotation2) {
-        this.animationSpeedOld = this.animationSpeed;
-        double d1 = this.getX() - this.xo;
-        double d0 = this.getZ() - this.zo;
-        float f1 = -Mth.sqrt((float) (d1 * d1 + d0 * d0)) * rotation1;
-        if (f1 > 1.0F)
-            f1 = 1.0F;
-        this.animationSpeed += (f1 - this.animationSpeed) * rotation2;
-        this.animationPosition += this.animationSpeed;
-    }
-
-    public void setWellRotationPlus(float rotation1, float rotation2) {
-        this.animationSpeedOld = this.animationSpeed;
-        double d1 = this.getX() - this.xo;
-        double d0 = this.getZ() - this.zo;
-        float f1 = Mth.sqrt((float) (d1 * d1 + d0 * d0)) * rotation1;
-        if (f1 > 1.0F)
-            f1 = 1.0F;
-        this.animationSpeed += (f1 - this.animationSpeed) * rotation2;
-        this.animationPosition += this.animationSpeed;
-    }
-
-    public void calculateEntityAnimation(RoverEntity p_21044_, boolean p_21045_) {
-        p_21044_.animationSpeedOld = p_21044_.animationSpeed;
-        double d0 = p_21044_.getX() - p_21044_.xo;
-        double d1 = p_21045_ ? p_21044_.getY() - p_21044_.yo : 0.0D;
-        double d2 = p_21044_.getZ() - p_21044_.zo;
-        float f = (float)Math.sqrt(d0 * d0 + d1 * d1 + d2 * d2) * 4.0F;
-        if (f > 1.0F) {
-            f = 1.0F;
-        }
-        p_21044_.animationSpeed += (f - p_21044_.animationSpeed) * 0.4F;
-        p_21044_.animationPosition += p_21044_.animationSpeed;
-    }
+	public RoverEntity(EntityType type, Level worldIn) {
+		super(type, worldIn);
+		this.entityData.define(FUEL, 0);
+		this.entityData.define(FORWARD, false);
+	}
+
+	@Override
+	public boolean isPushable() {
+		return false;
+	}
+
+	@Override
+	public boolean canBeCollidedWith() {
+		return false;
+	}
+
+	@Override
+	public void push(Entity p_21294_) {
+	}
+
+	@Deprecated
+	public boolean canBeRiddenInWater() {
+		return true;
+	}
+
+	@Override
+	public boolean rideableUnderWater() {
+		return true;
+	}
+
+	@Override
+	public double getPassengersRidingOffset() {
+		return super.getPassengersRidingOffset() - 0.15;
+	}
+
+	@OnlyIn(Dist.CLIENT)
+	@Override
+	public void onPassengerTurned(Entity p_20320_) {
+		this.applyYawToEntity(p_20320_);
+	}
+
+	@Override
+	public Vec3 getDismountLocationForPassenger(LivingEntity livingEntity) {
+		Vec3[] avector3d = new Vec3[] { getCollisionHorizontalEscapeVector((double) this.getBbWidth(), (double) livingEntity.getBbWidth(), livingEntity.getYRot()), getCollisionHorizontalEscapeVector((double) this.getBbWidth(), (double) livingEntity.getBbWidth(), livingEntity.getYRot() - 22.5F), getCollisionHorizontalEscapeVector((double) this.getBbWidth(), (double) livingEntity.getBbWidth(), livingEntity.getYRot() + 22.5F), getCollisionHorizontalEscapeVector((double) this.getBbWidth(), (double) livingEntity.getBbWidth(), livingEntity.getYRot() - 45.0F), getCollisionHorizontalEscapeVector((double) this.getBbWidth(), (double) livingEntity.getBbWidth(), livingEntity.getYRot() + 45.0F) };
+		Set<BlockPos> set = Sets.newLinkedHashSet();
+		double d0 = this.getBoundingBox().maxY;
+		double d1 = this.getBoundingBox().minY - 0.5D;
+		BlockPos.MutableBlockPos blockpos$mutable = new BlockPos.MutableBlockPos();
+
+		for (Vec3 vector3d : avector3d) {
+			blockpos$mutable.set(this.getX() + vector3d.x, d0, this.getZ() + vector3d.z);
+
+			for (double d2 = d0; d2 > d1; --d2) {
+				set.add(blockpos$mutable.immutable());
+				blockpos$mutable.move(Direction.DOWN);
+			}
+		}
+
+		for (BlockPos blockpos : set) {
+			if (!this.level.getFluidState(blockpos).is(FluidTags.LAVA)) {
+				double d3 = this.level.getBlockFloorHeight(blockpos);
+				if (DismountHelper.isBlockFloorValid(d3)) {
+					Vec3 vector3d1 = Vec3.upFromBottomCenterOf(blockpos, d3);
+
+					for (Pose pose : livingEntity.getDismountPoses()) {
+						AABB axisalignedbb = livingEntity.getLocalBoundsForPose(pose);
+						if (DismountHelper.isBlockFloorValid(this.level.getBlockFloorHeight(blockpos))) {
+							livingEntity.setPose(pose);
+							return vector3d1;
+						}
+					}
+				}
+			}
+		}
+
+		return new Vec3(this.getX(), this.getBoundingBox().maxY, this.getZ());
+	}
+
+	protected void applyYawToEntity(Entity entityToUpdate) {
+		entityToUpdate.setYBodyRot(this.getYRot());
+		float f = Mth.wrapDegrees(entityToUpdate.getYRot() - this.getYRot());
+		float f1 = Mth.clamp(f, -105.0F, 105.0F);
+		entityToUpdate.yRotO += f1 - f;
+		entityToUpdate.setYRot(entityToUpdate.getYRot() + f1 - f);
+		entityToUpdate.setYHeadRot(entityToUpdate.getYRot());
+	}
+
+	@Override
+	protected void removePassenger(Entity passenger) {
+		if (passenger.isCrouching() && !passenger.level.isClientSide) {
+			if (passenger instanceof ServerPlayer) {
+				this.setSpeed(0f);
+			}
+		}
+		super.removePassenger(passenger);
+	}
+
+	@Override
+	public ItemStack getPickedResult(HitResult target) {
+		ItemStack itemStack = new ItemStack(ItemsRegistry.ROVER_ITEM.get(), 1);
+		itemStack.getOrCreateTag().putInt(RoverItem.fuelTag, this.getFuel());
+
+		return itemStack;
+	}
+
+	@Override
+	public void kill() {
+		this.spawnRoverItem();
+		this.dropEquipment();
+
+		if (!this.level.isClientSide) {
+			this.remove(RemovalReason.DISCARDED);
+		}
+	}
+
+	@Override
+	public AABB getBoundingBoxForCulling() {
+		return new AABB(this.getX(), this.getY(), this.getZ(), this.getX(), this.getY(), this.getZ()).inflate(4.5, 4.5, 4.5);
+	}
+
+	@Override
+	public boolean hurt(DamageSource source, float p_21017_) {
+		if (!source.isProjectile() && source.getEntity() != null && source.getEntity().isCrouching() && !this.isVehicle()) {
+			this.spawnRoverItem();
+			this.dropEquipment();
+
+			if (!this.level.isClientSide) {
+				this.remove(RemovalReason.DISCARDED);
+			}
+			return true;
+		}
+
+		return false;
+	}
+
+	protected void spawnRoverItem() {
+		ItemStack itemStack = new ItemStack(ItemsRegistry.ROVER_ITEM.get(), 1);
+		itemStack.getOrCreateTag().putInt(BeyondEarthMod.MODID + ":fuel", this.getFuel());
+
+		ItemEntity entityToSpawn = new ItemEntity(level, this.getX(), this.getY(), this.getZ(), itemStack);
+		entityToSpawn.setPickUpDelay(10);
+		level.addFreshEntity(entityToSpawn);
+	}
+
+	protected void dropEquipment() {
+		for (int i = 0; i < inventory.getSlots(); ++i) {
+			ItemStack itemstack = inventory.getStackInSlot(i);
+			if (!itemstack.isEmpty() && !EnchantmentHelper.hasVanishingCurse(itemstack)) {
+				this.spawnAtLocation(itemstack);
+			}
+		}
+	}
+
+	private final ItemStackHandler inventory = new ItemStackHandler(9) {
+		@Override
+		public int getSlotLimit(int slot) {
+			return 64;
+		}
+	};
+
+	private final CombinedInvWrapper combined = new CombinedInvWrapper(inventory);
+
+	@Override
+	public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction side) {
+		if (this.isAlive() && capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && side == null) {
+			return LazyOptional.of(() -> combined).cast();
+		}
+		return super.getCapability(capability, side);
+	}
+
+	public IItemHandlerModifiable getItemHandler() {
+		return (IItemHandlerModifiable) this.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).resolve().get();
+	}
+
+	@Override
+	public void addAdditionalSaveData(CompoundTag compound) {
+		compound.put("InventoryCustom", inventory.serializeNBT());
+
+		compound.putInt("fuel", this.getFuel());
+		compound.putBoolean("forward", this.getEntityData().get(FORWARD));
+	}
+
+	@Override
+	public void readAdditionalSaveData(CompoundTag compound) {
+		Tag inventoryCustom = compound.get("InventoryCustom");
+		if (inventoryCustom instanceof CompoundTag) {
+			inventory.deserializeNBT((CompoundTag) inventoryCustom);
+		}
+
+		this.setFuel(compound.getInt("fuel"));
+		this.entityData.set(FORWARD, compound.getBoolean("forward"));
+	}
+
+	@Override
+	public InteractionResult interact(Player player, InteractionHand hand) {
+		super.interact(player, hand);
+		InteractionResult result = InteractionResult.sidedSuccess(this.level.isClientSide);
+
+		if (!this.level.isClientSide) {
+			if (player.isCrouching()) {
+				NetworkHooks.openGui((ServerPlayer) player, new MenuProvider() {
+					@Override
+					public Component getDisplayName() {
+						return RoverEntity.this.getDisplayName();
+					}
+
+					@Override
+					public AbstractContainerMenu createMenu(int id, Inventory inventory, Player player) {
+						FriendlyByteBuf packetBuffer = new FriendlyByteBuf(Unpooled.buffer());
+						packetBuffer.writeVarInt(RoverEntity.this.getId());
+						return new RoverGui.GuiContainer(id, inventory, packetBuffer);
+					}
+				}, buf -> {
+					buf.writeVarInt(this.getId());
+				});
+
+				return InteractionResult.CONSUME;
+			}
+
+			player.startRiding(this);
+			return InteractionResult.CONSUME;
+		}
+
+		return result;
+	}
+
+	public boolean getforward() {
+		return this.entityData.get(FORWARD);
+	}
+
+	@Override
+	public void tick() {
+		super.tick();
+
+		/** Reset Fall Damage for Passengers too */
+		this.resetFallDistance();
+
+		// Fuel Load up
+		if (Methods.tagCheck(FluidUtil2.findBucketFluid(this.inventory.getStackInSlot(0).getItem()), TagsRegistry.FLUID_VEHICLE_FUEL_TAG)) {
+
+			if (this.canPutFuelMuchAsBucket()) {
+				this.putFuelMuchAsBucket();
+				this.inventory.setStackInSlot(0, new ItemStack(Items.BUCKET));
+			}
+		}
+
+		if (this.getPassengers().isEmpty()) {
+			return;
+		}
+
+		if (!(this.getPassengers().get(0) instanceof Player)) {
+			return;
+		}
+
+		if (this.isEyeInFluid(FluidTags.WATER)) {
+			return;
+		}
+
+		FUEL_TIMER++;
+
+		Player passanger = (Player) this.getPassengers().get(0);
+
+		passanger.resetFallDistance();
+
+		if (passanger.zza > 0.01 && this.getFuel() != 0) {
+
+			if (FUEL_TIMER > FUEL_USE_TICK) {
+				this.setFuel(this.getFuel() - 1);
+				FUEL_TIMER = 0;
+			}
+			this.entityData.set(FORWARD, true);
+		} else if (passanger.zza < -0.01 && this.getFuel() != 0) {
+
+			if (FUEL_TIMER > FUEL_USE_TICK) {
+				this.setFuel(this.getFuel() - 1);
+				FUEL_TIMER = 0;
+			}
+			this.entityData.set(FORWARD, false);
+		}
+	}
+
+	@Override
+	public float getFrictionInfluencedSpeed(float p_21331_) {
+		return this.onGround ? this.getSpeed() * (0.21600002F / (p_21331_ * p_21331_ * p_21331_)) : this.flyingSpeed;
+	}
+
+	@Override
+	public void travel(Vec3 p_21280_) {
+		this.calculateEntityAnimation(this, this instanceof FlyingAnimal);
+
+		if (!this.getPassengers().isEmpty() && this.getPassengers().get(0) instanceof Player) {
+
+			Player passanger = (Player) this.getPassengers().get(0);
+
+			this.flyingSpeed = this.getSpeed() * 0.15F;
+			this.maxUpStep = 1.0F;
+
+			double pmovement = passanger.zza;
+
+			if (pmovement == 0 || this.getFuel() == 0 || this.isEyeInFluid(FluidTags.WATER)) {
+				pmovement = 0;
+				this.setSpeed(0f);
+
+				if (speed != 0 && speed > 0.02) {
+					speed = speed - 0.02;
+				}
+			}
+
+			if (this.entityData.get(FORWARD) && this.getFuel() != 0) {
+				if (this.getSpeed() >= 0.01) {
+					if (speed <= 0.32) {
+						speed = speed + 0.02;
+					}
+				}
+
+				if (this.getSpeed() < 0.25) {
+					this.setSpeed(this.getSpeed() + 0.02F);
+				}
+
+			}
+
+			if (!this.entityData.get(FORWARD)) {
+
+				if (this.getFuel() != 0 && !this.isEyeInFluid(FluidTags.WATER)) {
+
+					if (this.getSpeed() <= 0.04) {
+						this.setSpeed(this.getSpeed() + 0.02f);
+					}
+				}
+
+				if (this.getSpeed() >= 0.08) {
+					this.setSpeed(0f);
+				}
+			}
+
+			if (this.entityData.get(FORWARD)) {
+				this.setWellRotationPlus(4.0f, 0.4f);
+			} else {
+				this.setWellRotationMinus(8.0f, 0.8f);
+			}
+
+			super.travel(new Vec3(0, 0, pmovement));
+			return;
+		}
+
+		super.travel(new Vec3(0, 0, 0));
+	}
+
+	public void setWellRotationMinus(float rotation1, float rotation2) {
+		this.animationSpeedOld = this.animationSpeed;
+		double d1 = this.getX() - this.xo;
+		double d0 = this.getZ() - this.zo;
+		float f1 = -Mth.sqrt((float) (d1 * d1 + d0 * d0)) * rotation1;
+		if (f1 > 1.0F)
+			f1 = 1.0F;
+		this.animationSpeed += (f1 - this.animationSpeed) * rotation2;
+		this.animationPosition += this.animationSpeed;
+	}
+
+	public void setWellRotationPlus(float rotation1, float rotation2) {
+		this.animationSpeedOld = this.animationSpeed;
+		double d1 = this.getX() - this.xo;
+		double d0 = this.getZ() - this.zo;
+		float f1 = Mth.sqrt((float) (d1 * d1 + d0 * d0)) * rotation1;
+		if (f1 > 1.0F)
+			f1 = 1.0F;
+		this.animationSpeed += (f1 - this.animationSpeed) * rotation2;
+		this.animationPosition += this.animationSpeed;
+	}
+
+	public void calculateEntityAnimation(RoverEntity p_21044_, boolean p_21045_) {
+		p_21044_.animationSpeedOld = p_21044_.animationSpeed;
+		double d0 = p_21044_.getX() - p_21044_.xo;
+		double d1 = p_21045_ ? p_21044_.getY() - p_21044_.yo : 0.0D;
+		double d2 = p_21044_.getZ() - p_21044_.zo;
+		float f = (float) Math.sqrt(d0 * d0 + d1 * d1 + d2 * d2) * 4.0F;
+		if (f > 1.0F) {
+			f = 1.0F;
+		}
+		p_21044_.animationSpeed += (f - p_21044_.animationSpeed) * 0.4F;
+		p_21044_.animationPosition += p_21044_.animationSpeed;
+	}
 
 	@Override
 	public int getFuel() {
@@ -477,5 +485,12 @@ public class RoverEntity extends VehicleEntity implements IFuelVehicleEntity {
 	@Override
 	public boolean canPutFuelMuchAsBucket() {
 		return (this.getFuel() + FluidUtil2.BUCKET_SIZE) <= this.getFuelCapacity();
+	}
+
+	@Override
+	public List<IGaugeValue> getGaugeValues() {
+		List<IGaugeValue> list = new ArrayList<>();
+		list.add(this.getFuelGauge());
+		return list;
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rocket/RocketGui.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rocket/RocketGui.java
@@ -27,12 +27,12 @@ public class RocketGui {
 
 
 	public static class GuiContainer extends AbstractContainerMenu {
-		Entity rocket;
+		private final IRocketEntity rocket;
 
 		public GuiContainer(int id, Inventory inv, FriendlyByteBuf extraData) {
 			super(ScreensRegistry.ROCKET_GUI.get(), id);
 
-			this.rocket = inv.player.level.getEntity(extraData.readVarInt());
+			this.rocket = (IRocketEntity) inv.player.level.getEntity(extraData.readVarInt());
 
 			IItemHandlerModifiable itemHandler = null;
 
@@ -58,6 +58,10 @@ public class RocketGui {
 		@Override
 		public ItemStack quickMoveStack(Player playerIn, int index) {
 			return ContainerHelper.transferStackInSlot(this, playerIn, index, 0, 1, this::moveItemStackTo);
+		}
+
+		public IRocketEntity getRocket() {
+			return this.rocket;
 		}
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rocket/RocketGuiWindow.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rocket/RocketGuiWindow.java
@@ -80,19 +80,17 @@ public class RocketGuiWindow extends AbstractContainerScreen<RocketGui.GuiContai
 
 	public IGaugeValue getFuelGaugeValue() {
 		int fuel = 0;
+		int capacity = 0;
 
-		if (menu.rocket instanceof IRocketEntity) {
-			fuel = menu.rocket.getEntityData().get(IRocketEntity.FUEL);
+		if (menu.getRocket() instanceof IFuelRocketEntity fuelRocket) {
+			fuel = fuelRocket.getFuel();
+			capacity = fuelRocket.getFuelCapacity();
 		}
 
-		return GaugeValueHelper.getFuel(fuel / 3, 100);
+		return GaugeValueHelper.getFuel(fuel, capacity);
 	}
 
 	public Rectangle2d getFluidBounds() {
 		return GuiHelper.getRocketFluidTankBounds(66, 21);
-	}
-
-	public Entity getRocket() {
-		return menu.rocket;
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rover/RoverGui.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rover/RoverGui.java
@@ -1,7 +1,6 @@
 package net.mrscauthd.beyond_earth.guis.screens.rover;
 
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -26,12 +25,12 @@ public class RoverGui {
 	}
 
 	public static class GuiContainer extends AbstractContainerMenu {
-		Entity rover;
+		private final RoverEntity rover;
 
 		public GuiContainer(int id, Inventory inv, FriendlyByteBuf extraData) {
 			super(ScreensRegistry.ROVER_GUI.get(), id);
 
-			this.rover = inv.player.level.getEntity(extraData.readVarInt());
+			this.rover = (RoverEntity) inv.player.level.getEntity(extraData.readVarInt());
 
 			IItemHandlerModifiable itemHandler = ((RoverEntity) rover).getItemHandler();
 			this.addSlot(new SlotItemHandler(itemHandler, 0, 8, 63) {
@@ -62,6 +61,10 @@ public class RoverGui {
 		@Override
 		public ItemStack quickMoveStack(Player playerIn, int index) {
 			return ContainerHelper.transferStackInSlot(this, playerIn, index, 0, 9, this::moveItemStackTo);
+		}
+		
+		public RoverEntity getRover() {
+			return this.rover;
 		}
 	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rover/RoverGuiWindow.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/guis/screens/rover/RoverGuiWindow.java
@@ -18,10 +18,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fluids.FluidStack;
 import net.mrscauthd.beyond_earth.BeyondEarthMod;
 import net.mrscauthd.beyond_earth.compats.CompatibleManager;
-import net.mrscauthd.beyond_earth.entities.RoverEntity;
-import net.mrscauthd.beyond_earth.fluids.FluidUtil2;
 import net.mrscauthd.beyond_earth.gauge.GaugeTextHelper;
-import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
 import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
 import net.mrscauthd.beyond_earth.guis.helper.GuiHelper;
 import net.mrscauthd.beyond_earth.registries.BlocksRegistry;
@@ -47,10 +44,8 @@ public class RoverGuiWindow extends AbstractContainerScreen<RoverGui.GuiContaine
 
 		List<Component> fuelToolTip = new ArrayList<Component>();
 
-		int fuel = menu.rover.getEntityData().get(RoverEntity.FUEL);
-
 		if (!CompatibleManager.JEI.isLoaded() && GuiHelper.isHover(this.getFluidBounds(), mouseX - this.leftPos, mouseY - this.topPos)) {
-			fuelToolTip.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getStorageText(GaugeValueHelper.getFuel(fuel, RoverEntity.FUEL_BUCKETS * FluidUtil2.BUCKET_SIZE)), ChatFormatting.WHITE));
+			fuelToolTip.add(this.getFuelGaugeComponent());
 			this.renderComponentTooltip(ms, fuelToolTip, mouseX, mouseY);
 		}
 	}
@@ -64,7 +59,7 @@ public class RoverGuiWindow extends AbstractContainerScreen<RoverGui.GuiContaine
 		RenderSystem.setShaderTexture(0, texture);
 		GuiComponent.blit(ms, this.leftPos, this.topPos, 0, 0, this.imageWidth, this.imageHeight, this.imageWidth, this.imageHeight);
 
-		IGaugeValue fuelGaugeValue = this.getFuelGaugeValue();
+		IGaugeValue fuelGaugeValue = this.getMenu().getRover().getFuelGauge();
 		FluidStack fluidStack = new FluidStack(BlocksRegistry.FUEL_BLOCK.get().getFluid(), fuelGaugeValue.getAmount());
 		GuiHelper.drawFluidTank(ms, this.leftPos + 9, this.topPos + 11, fluidStack, fuelGaugeValue.getCapacity());
 	}
@@ -76,12 +71,7 @@ public class RoverGuiWindow extends AbstractContainerScreen<RoverGui.GuiContaine
 	}
 
 	public Component getFuelGaugeComponent() {
-		return GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getPercentText(this.getFuelGaugeValue()), ChatFormatting.WHITE);
-	}
-
-	public IGaugeValue getFuelGaugeValue() {
-		int fuel = menu.rover.getEntityData().get(RoverEntity.FUEL);
-		return GaugeValueHelper.getFuel(fuel, RoverEntity.FUEL_BUCKETS * FluidUtil2.BUCKET_SIZE);
+		return GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getStorageText(this.getMenu().getRover().getFuelGauge()), ChatFormatting.WHITE);
 	}
 
 	public Rectangle2d getFluidBounds() {

--- a/src/main/java/net/mrscauthd/beyond_earth/items/IFuelRocketItem.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/items/IFuelRocketItem.java
@@ -1,0 +1,79 @@
+package net.mrscauthd.beyond_earth.items;
+
+import java.util.List;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import net.mrscauthd.beyond_earth.BeyondEarthMod;
+import net.mrscauthd.beyond_earth.entities.IFuelRocketEntity;
+import net.mrscauthd.beyond_earth.entities.IRocketEntity;
+import net.mrscauthd.beyond_earth.gauge.GaugeTextHelper;
+import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
+
+public abstract class IFuelRocketItem extends IRocketItem implements IFuelVehicleItem {
+
+	public static final String fuelTag = BeyondEarthMod.MODID + ":fuel";
+	public static final String bucketTag = BeyondEarthMod.MODID + ":buckets";
+
+	public IFuelRocketItem(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	public void appendHoverText(ItemStack itemstack, Level world, List<Component> list, TooltipFlag flag) {
+		super.appendHoverText(itemstack, world, list, flag);
+
+		IGaugeValue fuelGauge = this.getFuelGauge(itemstack);
+		list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getPercentText(fuelGauge)));
+	}
+
+	@Override
+	public void fillItemCategory(CreativeModeTab tab, NonNullList<ItemStack> list) {
+		super.fillItemCategory(tab, list);
+		if (this.allowdedIn(tab)) {
+			ItemStack itemStack = new ItemStack(this);
+			this.setFuel(itemStack, this.getFuelCapacity(itemStack));
+			list.add(itemStack);
+		}
+	}
+
+	@Override
+	protected void onRocketPlaced(IRocketEntity rocket, ItemStack itemStack) {
+		super.onRocketPlaced(rocket, itemStack);
+
+		if (rocket instanceof IFuelRocketEntity fuelRocket) {
+			fuelRocket.setFuel(this.getFuel(itemStack));
+			fuelRocket.setBucket(this.getBucket(itemStack));
+		}
+
+	}
+
+	@Override
+	public int getFuel(ItemStack itemStack) {
+		return itemStack.getOrCreateTag().getInt(fuelTag);
+	}
+
+	@Override
+	public void setFuel(ItemStack itemStack, int fuel) {
+		itemStack.getOrCreateTag().putInt(fuelTag, Mth.clamp(fuel, 0, this.getFuelCapacity(itemStack)));
+	}
+
+	@Override
+	public int getFuelCapacity(ItemStack itemStack) {
+		return this.getRequiredFuelBuckets(itemStack) * this.getFuelOfBucket(itemStack);
+	}
+
+	public abstract int getRequiredFuelBuckets(ItemStack itemStack);
+
+	public abstract int getFuelOfBucket(ItemStack itemStack);
+
+	public int getBucket(ItemStack itemStack) {
+		return itemStack.getOrCreateTag().getInt(bucketTag);
+	}
+
+}

--- a/src/main/java/net/mrscauthd/beyond_earth/items/IFuelVehicleItem.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/items/IFuelVehicleItem.java
@@ -1,0 +1,21 @@
+package net.mrscauthd.beyond_earth.items;
+
+import net.minecraft.world.item.ItemStack;
+import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
+import net.mrscauthd.beyond_earth.gauge.IGaugeValue;
+
+public interface IFuelVehicleItem {
+
+	public int getFuel(ItemStack itemStack);
+
+	public void setFuel(ItemStack itemStack, int fuel);
+
+	public int getFuelCapacity(ItemStack itemStack);
+
+	public default IGaugeValue getFuelGauge(ItemStack itemStack) {
+		int fuel = this.getFuel(itemStack);
+		int capacity = this.getFuelCapacity(itemStack);
+		return GaugeValueHelper.getFuel(fuel, capacity);
+	}
+
+}

--- a/src/main/java/net/mrscauthd/beyond_earth/items/IRocketItem.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/items/IRocketItem.java
@@ -2,7 +2,6 @@ package net.mrscauthd.beyond_earth.items;
 
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
@@ -12,7 +11,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
@@ -23,22 +21,14 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.IItemRenderProperties;
 import net.minecraftforge.common.MinecraftForge;
-import net.mrscauthd.beyond_earth.BeyondEarthMod;
 import net.mrscauthd.beyond_earth.blocks.RocketLaunchPad;
 import net.mrscauthd.beyond_earth.entities.IRocketEntity;
-import net.mrscauthd.beyond_earth.entities.RocketTier1Entity;
 import net.mrscauthd.beyond_earth.events.forge.PlaceRocketEvent;
-import net.mrscauthd.beyond_earth.gauge.GaugeTextHelper;
-import net.mrscauthd.beyond_earth.gauge.GaugeValueHelper;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Consumer;
 
 public abstract class IRocketItem extends VehicleItem {
-
-    public static final String fuelTag = BeyondEarthMod.MODID + ":fuel";
-    public static final String bucketTag = BeyondEarthMod.MODID + ":buckets";
 
     public IRocketItem(Properties p_41383_) {
         super(p_41383_);
@@ -92,8 +82,7 @@ public abstract class IRocketItem extends VehicleItem {
                     level.addFreshEntity(rocket);
 
                     /** SET TAGS */
-                    rocket.getEntityData().set(RocketTier1Entity.FUEL, itemStack.getOrCreateTag().getInt(fuelTag));
-                    rocket.getEntityData().set(RocketTier1Entity.BUCKETS, itemStack.getOrCreateTag().getInt(bucketTag));
+                    this.onRocketPlaced(rocket, itemStack);
 
                     /** CALL PLACE ROCKET EVENT */
                     MinecraftForge.EVENT_BUS.post(new PlaceRocketEvent(rocket, context));
@@ -114,12 +103,8 @@ public abstract class IRocketItem extends VehicleItem {
         return super.useOn(context);
     }
 
-    @Override
-    public void appendHoverText(ItemStack itemstack, Level world, List<Component> list, TooltipFlag flag) {
-        super.appendHoverText(itemstack, world, list, flag);
-
-        int fuel = itemstack.getOrCreateTag().getInt(fuelTag) / 3;
-        list.add(GaugeTextHelper.buildBlockTooltip(GaugeTextHelper.getPercentText(GaugeValueHelper.getFuel(fuel, 100))));
+    protected void onRocketPlaced(IRocketEntity rocket, ItemStack itemStack) {
+    	
     }
 
     @Override

--- a/src/main/java/net/mrscauthd/beyond_earth/items/Tier1RocketItem.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/items/Tier1RocketItem.java
@@ -1,9 +1,7 @@
 package net.mrscauthd.beyond_earth.items;
 
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
-import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
@@ -13,34 +11,34 @@ import net.mrscauthd.beyond_earth.entities.RocketTier1Entity;
 import net.mrscauthd.beyond_earth.events.ClientEventBusSubscriber;
 import net.mrscauthd.beyond_earth.registries.EntitiesRegistry;
 
-public class Tier1RocketItem extends IRocketItem {
-    public Tier1RocketItem(Properties properties) {
-        super(properties);
-    }
+public class Tier1RocketItem extends IFuelRocketItem {
+	public Tier1RocketItem(Properties properties) {
+		super(properties);
+	}
 
-    @OnlyIn(Dist.CLIENT)
-    @Override
-    public BlockEntityWithoutLevelRenderer getRenderer() {
-        return ClientEventBusSubscriber.ROCKET_TIER_1_ITEM_RENDERER;
-    }
+	@OnlyIn(Dist.CLIENT)
+	@Override
+	public BlockEntityWithoutLevelRenderer getRenderer() {
+		return ClientEventBusSubscriber.ROCKET_TIER_1_ITEM_RENDERER;
+	}
 
-    @Override
-    public EntityType getEntityType() {
-        return EntitiesRegistry.TIER_1_ROCKET.get();
-    }
+	@Override
+	public EntityType getEntityType() {
+		return EntitiesRegistry.TIER_1_ROCKET.get();
+	}
 
-    @Override
-    public IRocketEntity getRocket(Level level) {
-        return new RocketTier1Entity(EntitiesRegistry.TIER_1_ROCKET.get(), level);
-    }
+	@Override
+	public IRocketEntity getRocket(Level level) {
+		return new RocketTier1Entity(EntitiesRegistry.TIER_1_ROCKET.get(), level);
+	}
 
-    @Override
-    public void fillItemCategory(CreativeModeTab p_41391_, NonNullList<ItemStack> p_41392_) {
-        super.fillItemCategory(p_41391_, p_41392_);
-        if (this.allowdedIn(p_41391_)) {
-            ItemStack itemStack = new ItemStack(this);
-            itemStack.getOrCreateTag().putInt(fuelTag, 300);
-            p_41392_.add(itemStack);
-        }
-    }
+	@Override
+	public int getFuelOfBucket(ItemStack itemStack) {
+		return RocketTier1Entity.FUEL_OF_BUCKET;
+	}
+
+	@Override
+	public int getRequiredFuelBuckets(ItemStack itemStack) {
+		return RocketTier1Entity.FUEL_BUCKETS;
+	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/items/Tier2RocketItem.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/items/Tier2RocketItem.java
@@ -1,9 +1,7 @@
 package net.mrscauthd.beyond_earth.items;
 
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
-import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
@@ -13,34 +11,34 @@ import net.mrscauthd.beyond_earth.entities.RocketTier2Entity;
 import net.mrscauthd.beyond_earth.events.ClientEventBusSubscriber;
 import net.mrscauthd.beyond_earth.registries.EntitiesRegistry;
 
-public class Tier2RocketItem extends IRocketItem {
-    public Tier2RocketItem(Properties properties) {
-        super(properties);
-    }
+public class Tier2RocketItem extends IFuelRocketItem {
+	public Tier2RocketItem(Properties properties) {
+		super(properties);
+	}
 
-    @OnlyIn(Dist.CLIENT)
-    @Override
-    public BlockEntityWithoutLevelRenderer getRenderer() {
-        return ClientEventBusSubscriber.ROCKET_TIER_2_ITEM_RENDERER;
-    }
+	@OnlyIn(Dist.CLIENT)
+	@Override
+	public BlockEntityWithoutLevelRenderer getRenderer() {
+		return ClientEventBusSubscriber.ROCKET_TIER_2_ITEM_RENDERER;
+	}
 
-    @Override
-    public EntityType getEntityType() {
-        return EntitiesRegistry.TIER_2_ROCKET.get();
-    }
+	@Override
+	public EntityType getEntityType() {
+		return EntitiesRegistry.TIER_2_ROCKET.get();
+	}
 
-    @Override
-    public IRocketEntity getRocket(Level level) {
-        return new RocketTier2Entity(EntitiesRegistry.TIER_2_ROCKET.get(), level);
-    }
+	@Override
+	public IRocketEntity getRocket(Level level) {
+		return new RocketTier2Entity(EntitiesRegistry.TIER_2_ROCKET.get(), level);
+	}
 
-    @Override
-    public void fillItemCategory(CreativeModeTab p_41391_, NonNullList<ItemStack> p_41392_) {
-        super.fillItemCategory(p_41391_, p_41392_);
-        if (this.allowdedIn(p_41391_)) {
-            ItemStack itemStack = new ItemStack(this);
-            itemStack.getOrCreateTag().putInt(fuelTag, 300);
-            p_41392_.add(itemStack);
-        }
-    }
+	@Override
+	public int getFuelOfBucket(ItemStack itemStack) {
+		return RocketTier2Entity.FUEL_OF_BUCKET;
+	}
+
+	@Override
+	public int getRequiredFuelBuckets(ItemStack itemStack) {
+		return RocketTier2Entity.FUEL_BUCKETS;
+	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/items/Tier3RocketItem.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/items/Tier3RocketItem.java
@@ -1,9 +1,7 @@
 package net.mrscauthd.beyond_earth.items;
 
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
-import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
@@ -13,34 +11,34 @@ import net.mrscauthd.beyond_earth.entities.RocketTier3Entity;
 import net.mrscauthd.beyond_earth.events.ClientEventBusSubscriber;
 import net.mrscauthd.beyond_earth.registries.EntitiesRegistry;
 
-public class Tier3RocketItem extends IRocketItem {
-    public Tier3RocketItem(Properties properties) {
-        super(properties);
-    }
+public class Tier3RocketItem extends IFuelRocketItem {
+	public Tier3RocketItem(Properties properties) {
+		super(properties);
+	}
 
-    @OnlyIn(Dist.CLIENT)
-    @Override
-    public BlockEntityWithoutLevelRenderer getRenderer() {
-        return ClientEventBusSubscriber.ROCKET_TIER_3_ITEM_RENDERER;
-    }
+	@OnlyIn(Dist.CLIENT)
+	@Override
+	public BlockEntityWithoutLevelRenderer getRenderer() {
+		return ClientEventBusSubscriber.ROCKET_TIER_3_ITEM_RENDERER;
+	}
 
-    @Override
-    public EntityType getEntityType() {
-        return EntitiesRegistry.TIER_3_ROCKET.get();
-    }
+	@Override
+	public EntityType getEntityType() {
+		return EntitiesRegistry.TIER_3_ROCKET.get();
+	}
 
-    @Override
-    public IRocketEntity getRocket(Level level) {
-        return new RocketTier3Entity(EntitiesRegistry.TIER_3_ROCKET.get(), level);
-    }
+	@Override
+	public IRocketEntity getRocket(Level level) {
+		return new RocketTier3Entity(EntitiesRegistry.TIER_3_ROCKET.get(), level);
+	}
 
-    @Override
-    public void fillItemCategory(CreativeModeTab p_41391_, NonNullList<ItemStack> p_41392_) {
-        super.fillItemCategory(p_41391_, p_41392_);
-        if (this.allowdedIn(p_41391_)) {
-            ItemStack itemStack = new ItemStack(this);
-            itemStack.getOrCreateTag().putInt(fuelTag, 300);
-            p_41392_.add(itemStack);
-        }
-    }
+	@Override
+	public int getFuelOfBucket(ItemStack itemStack) {
+		return RocketTier3Entity.FUEL_OF_BUCKET;
+	}
+
+	@Override
+	public int getRequiredFuelBuckets(ItemStack itemStack) {
+		return RocketTier3Entity.FUEL_BUCKETS;
+	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/items/Tier4RocketItem.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/items/Tier4RocketItem.java
@@ -1,9 +1,7 @@
 package net.mrscauthd.beyond_earth.items;
 
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
-import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
@@ -13,34 +11,34 @@ import net.mrscauthd.beyond_earth.entities.RocketTier4Entity;
 import net.mrscauthd.beyond_earth.events.ClientEventBusSubscriber;
 import net.mrscauthd.beyond_earth.registries.EntitiesRegistry;
 
-public class Tier4RocketItem extends IRocketItem {
-    public Tier4RocketItem(Properties properties) {
-        super(properties);
-    }
+public class Tier4RocketItem extends IFuelRocketItem {
+	public Tier4RocketItem(Properties properties) {
+		super(properties);
+	}
 
-    @OnlyIn(Dist.CLIENT)
-    @Override
-    public BlockEntityWithoutLevelRenderer getRenderer() {
-        return ClientEventBusSubscriber.ROCKET_TIER_4_ITEM_RENDERER;
-    }
+	@OnlyIn(Dist.CLIENT)
+	@Override
+	public BlockEntityWithoutLevelRenderer getRenderer() {
+		return ClientEventBusSubscriber.ROCKET_TIER_4_ITEM_RENDERER;
+	}
 
-    @Override
-    public EntityType getEntityType() {
-        return EntitiesRegistry.TIER_4_ROCKET.get();
-    }
+	@Override
+	public EntityType getEntityType() {
+		return EntitiesRegistry.TIER_4_ROCKET.get();
+	}
 
-    @Override
-    public IRocketEntity getRocket(Level level) {
-        return new RocketTier4Entity(EntitiesRegistry.TIER_4_ROCKET.get(), level);
-    }
+	@Override
+	public IRocketEntity getRocket(Level level) {
+		return new RocketTier4Entity(EntitiesRegistry.TIER_4_ROCKET.get(), level);
+	}
 
-    @Override
-    public void fillItemCategory(CreativeModeTab p_41391_, NonNullList<ItemStack> p_41392_) {
-        super.fillItemCategory(p_41391_, p_41392_);
-        if (this.allowdedIn(p_41391_)) {
-            ItemStack itemStack = new ItemStack(this);
-            itemStack.getOrCreateTag().putInt(fuelTag, 300);
-            p_41392_.add(itemStack);
-        }
-    }
+	@Override
+	public int getFuelOfBucket(ItemStack itemStack) {
+		return RocketTier4Entity.FUEL_OF_BUCKET;
+	}
+
+	@Override
+	public int getRequiredFuelBuckets(ItemStack itemStack) {
+		return RocketTier4Entity.FUEL_BUCKETS;
+	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/jei/jeiguihandlers/RocketGuiContainerHandler.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/jei/jeiguihandlers/RocketGuiContainerHandler.java
@@ -13,6 +13,7 @@ import mezz.jei.api.runtime.IRecipesGui;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.mrscauthd.beyond_earth.entities.IRocketEntity;
 import net.mrscauthd.beyond_earth.entities.RocketTier1Entity;
 import net.mrscauthd.beyond_earth.entities.RocketTier2Entity;
 import net.mrscauthd.beyond_earth.entities.RocketTier3Entity;
@@ -22,41 +23,44 @@ import net.mrscauthd.beyond_earth.jei.JeiPlugin;
 
 public class RocketGuiContainerHandler implements IGuiContainerHandler<RocketGuiWindow> {
 
-    public RocketGuiContainerHandler() {
+	public RocketGuiContainerHandler() {
 
-    }
+	}
 
-    @Override
-    public Collection<IGuiClickableArea> getGuiClickableAreas(RocketGuiWindow containerScreen, double mouseX, double mouseY) {
-        return Collections.singleton(new IGuiClickableArea() {
-            @Override
-            public Rect2i getArea() {
-                return containerScreen.getFluidBounds().toRect2i();
-            }
+	@Override
+	public Collection<IGuiClickableArea> getGuiClickableAreas(RocketGuiWindow containerScreen, double mouseX, double mouseY) {
+		return Collections.singleton(new IGuiClickableArea() {
+			@Override
+			public Rect2i getArea() {
+				return containerScreen.getFluidBounds().toRect2i();
+			}
 
-            @Override
-            public void onClick(IFocusFactory focusFactory, IRecipesGui recipesGui) {
-                if (containerScreen.getRocket() instanceof RocketTier1Entity) {
-                    recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier1JeiCategory.recipeType));
-                }
-                if (containerScreen.getRocket() instanceof RocketTier2Entity) {
-                    recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier2JeiCategory.recipeType));
-                }
-                if (containerScreen.getRocket() instanceof RocketTier3Entity) {
-                    recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier3JeiCategory.recipeType));
-                }
-                if (containerScreen.getRocket() instanceof RocketTier4Entity) {
-                    recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier4JeiCategory.recipeType));
-                }
-            }
+			@Override
+			public void onClick(IFocusFactory focusFactory, IRecipesGui recipesGui) {
+				IRocketEntity rocket = containerScreen.getMenu().getRocket();
 
-            @Override
-            public List<Component> getTooltipStrings() {
-                List<Component> list = new ArrayList<>();
-                list.add(containerScreen.getFuelGaugeComponent());
-                list.add(new TranslatableComponent("jei.tooltip.show.recipes"));
-                return list;
-            }
-        });
-    }
+				if (rocket instanceof RocketTier1Entity) {
+					recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier1JeiCategory.recipeType));
+
+				} else if (rocket instanceof RocketTier2Entity) {
+					recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier2JeiCategory.recipeType));
+
+				} else if (rocket instanceof RocketTier3Entity) {
+					recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier3JeiCategory.recipeType));
+
+				} else if (rocket instanceof RocketTier4Entity) {
+					recipesGui.showTypes(Arrays.asList(JeiPlugin.RocketTier4JeiCategory.recipeType));
+
+				}
+			}
+
+			@Override
+			public List<Component> getTooltipStrings() {
+				List<Component> list = new ArrayList<>();
+				list.add(containerScreen.getFuelGaugeComponent());
+				list.add(new TranslatableComponent("jei.tooltip.show.recipes"));
+				return list;
+			}
+		});
+	}
 }

--- a/src/main/java/net/mrscauthd/beyond_earth/keybinds/KeyMethods.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/keybinds/KeyMethods.java
@@ -31,7 +31,7 @@ public class KeyMethods {
                 RoverEntity rover = (RoverEntity) player.getVehicle();
                 float forward = player.zza;
 
-                if (player.getVehicle().getEntityData().get(RoverEntity.FUEL) != 0 && !player.getVehicle().isEyeInFluid(FluidTags.WATER)) {
+                if (rover.getFuel() != 0 && !player.getVehicle().isEyeInFluid(FluidTags.WATER)) {
 
                     if (forward > 0) {
                         Methods.vehicleRotation(rover, rotationForward);

--- a/src/main/java/net/mrscauthd/beyond_earth/keybinds/KeyMethods.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/keybinds/KeyMethods.java
@@ -73,13 +73,13 @@ public class KeyMethods {
                 IRocketEntity rocket = (IRocketEntity) player.getVehicle();
                 SynchedEntityData data = rocket.getEntityData();
 
-                if (data.get(IRocketEntity.FUEL) == 300) {
+                if (rocket.canStart()) {
                     if (!data.get(IRocketEntity.ROCKET_START)) {
                         data.set(IRocketEntity.ROCKET_START, true);
                         Methods.playRocketSound(rocket, rocket.level);
                     }
                 } else {
-                    Methods.noFuelMessage(player);
+                    rocket.sendCantStartMessage(player);
                 }
             }
         }


### PR DESCRIPTION
* Add IFuelVehicleEntity, IFuelVehicleItem
     It will use at Vehicle using Fuel fluid
* Rover, Tier 1, 2, 3, 4 Rockets are implements it
* Other mods get standard method to access Vehicle's fuel
* Unify methods of each rockets fuel filling up
* Can change Vehicle's fuel bucket count to easy via getRequiredFuelBuckets method
    I will create new pr about that later
* Show vehicle's fuel on Jade / The One Probe
* I think require many test

![image](https://user-images.githubusercontent.com/44163945/185948619-711b8974-4f6f-49ce-bc12-78e0e65a9039.png)

![image](https://user-images.githubusercontent.com/44163945/185948652-bdab97de-cd75-42a2-b332-03942c344199.png)
