### PR TITLE
Support CraftTweaker's removeByOutput

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/crafting/ItemStackToItemStackRecipe.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/crafting/ItemStackToItemStackRecipe.java
@@ -54,6 +54,11 @@ public abstract class ItemStackToItemStackRecipe extends BeyondEarthRecipe imple
 		return true;
 	}
 	
+	@Override
+	public ItemStack getResultItem() {
+		return this.output.copy();
+	}
+	
 	public ItemStack getOutput() {
 		return this.output.copy();
 	}

--- a/src/main/java/net/mrscauthd/beyond_earth/crafting/ItemStackToItemStackRecipe.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/crafting/ItemStackToItemStackRecipe.java
@@ -21,7 +21,7 @@ public abstract class ItemStackToItemStackRecipe extends BeyondEarthRecipe imple
 		super(id, json);
 		this.input = Ingredient.fromJson(GsonHelper.getAsJsonObject(json, "input"));
 		this.output = CraftingHelper.getItemStack(GsonHelper.getAsJsonObject(json, "output"), true);
-		this.cookTime = GsonHelper.getAsInt(json, "cookTime");
+		this.cookTime = GsonHelper.getAsInt(json, "cookTime", this.getDefaultCookTime());
 	}
 
 	public ItemStackToItemStackRecipe(ResourceLocation id, FriendlyByteBuf buffer) {
@@ -42,6 +42,10 @@ public abstract class ItemStackToItemStackRecipe extends BeyondEarthRecipe imple
 		this.getInput().toNetwork(buffer);
 		buffer.writeItem(this.getOutput());
 		buffer.writeInt(this.getCookTime());
+	}
+	
+	protected int getDefaultCookTime() {
+		return 200;
 	}
 
 	@Override

--- a/src/main/java/net/mrscauthd/beyond_earth/crafting/WorkbenchingRecipe.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/crafting/WorkbenchingRecipe.java
@@ -109,6 +109,11 @@ public class WorkbenchingRecipe extends BeyondEarthRecipe implements BiPredicate
 	public boolean canCraftInDimensions(int var1, int var2) {
 		return false;
 	}
+	
+	@Override
+	public ItemStack getResultItem() {
+		return this.output.copy();
+	}
 
 	public ItemStack getOutput() {
 		return this.output.copy();


### PR DESCRIPTION
Usage
```ZS
<recipetype:beyond_earth:compressing>.remove(<item:beyond_earth:compressed_steel>);
```

And Declare default cook time at Compressing recipe (200 ticks)
Addon mod recipes will can override it
