### PR TITLE
Add Steel Items Management Config

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/config/Config.java
@@ -85,6 +85,9 @@ public class Config {
 	public static final ForgeConfigSpec.ConfigValue<Integer> ROCKET_TIER_4_FUEL_BUCKETS;
 	public static final ForgeConfigSpec.ConfigValue<Integer> ROCKET_TIER_4_FILL_UP_SPEED;
 
+	/** Steel Management */
+	public static final ForgeConfigSpec.ConfigValue<Integer> STEEL_MANAGEMENT;
+
 	static {
 		BUILDER.push("Beyond Earth Config");
 
@@ -197,6 +200,9 @@ public class Config {
 
 		BUILDER.pop();
 		/** End of Vehicles */
+
+		/** Steel Management */
+		STEEL_MANAGEMENT = BUILDER.comment("Management Steel Items", "0: Default, Nothing special, Use steel items as-is", "1: Iron Ingot can't blasting into be steel ingot", "2: Additionally, Steel Block and Ingot and Nugget are can't conversion to each shape", "    And hide Steel Block, Ingot, Nugget in JEI").defineInRange("Steel Management", 0, 0, 2);
 
 		BUILDER.pop();
 		SPEC = BUILDER.build();

--- a/src/main/java/net/mrscauthd/beyond_earth/crafting/conditions/ConfigSteelManagementCondition.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/crafting/conditions/ConfigSteelManagementCondition.java
@@ -1,0 +1,55 @@
+package net.mrscauthd.beyond_earth.crafting.conditions;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraftforge.common.crafting.conditions.ICondition;
+import net.minecraftforge.common.crafting.conditions.IConditionSerializer;
+import net.mrscauthd.beyond_earth.BeyondEarthMod;
+import net.mrscauthd.beyond_earth.config.Config;
+
+public class ConfigSteelManagementCondition implements ICondition {
+
+	public static final ResourceLocation NAME = new ResourceLocation(BeyondEarthMod.MODID, "steel_management");
+
+	private final int level;
+
+	public ConfigSteelManagementCondition(int level) {
+		this.level = level;
+	}
+
+	@Override
+	public ResourceLocation getID() {
+		return NAME;
+	}
+
+	@Override
+	public boolean test() {
+		return Config.STEEL_MANAGEMENT.get() < this.level;
+	}
+
+	@Override
+	public String toString() {
+		return "steel_management(\"" + this.level + "\")";
+	}
+
+	public static class Serializer implements IConditionSerializer<ConfigSteelManagementCondition> {
+		public static final Serializer INSTANCE = new Serializer();
+
+		@Override
+		public void write(JsonObject json, ConfigSteelManagementCondition value) {
+			json.addProperty("level", value.level);
+		}
+
+		@Override
+		public ConfigSteelManagementCondition read(JsonObject json) {
+			return new ConfigSteelManagementCondition(GsonHelper.getAsInt(json, "level"));
+		}
+
+		@Override
+		public ResourceLocation getID() {
+			return ConfigSteelManagementCondition.NAME;
+		}
+	}
+}

--- a/src/main/java/net/mrscauthd/beyond_earth/events/ConditionRegisterEvents.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/events/ConditionRegisterEvents.java
@@ -1,0 +1,18 @@
+package net.mrscauthd.beyond_earth.events;
+
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraftforge.common.crafting.CraftingHelper;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.mrscauthd.beyond_earth.BeyondEarthMod;
+import net.mrscauthd.beyond_earth.crafting.conditions.ConfigSteelManagementCondition;
+
+@EventBusSubscriber(modid = BeyondEarthMod.MODID, bus = Bus.MOD)
+public class ConditionRegisterEvents {
+	@SubscribeEvent
+	public static void registerRecipeSerializers(RegistryEvent.Register<RecipeSerializer<?>> event) {
+		CraftingHelper.register(ConfigSteelManagementCondition.Serializer.INSTANCE);
+	}
+}

--- a/src/main/java/net/mrscauthd/beyond_earth/jei/JeiPlugin.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/jei/JeiPlugin.java
@@ -44,6 +44,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.material.Fluid;
@@ -228,6 +229,14 @@ public class JeiPlugin implements IModPlugin {
 		Component oilDescriptionKey = new TranslatableComponent("jei.tooltip." + BeyondEarthMod.MODID + ".oil");
 		registration.addIngredientInfo(new ItemStack(ItemsRegistry.OIL_BUCKET.get(), 1), VanillaTypes.ITEM_STACK, oilDescriptionKey);
 		registration.addIngredientInfo(new FluidStack(FluidsRegistry.OIL_STILL.get(), 1000), ForgeTypes.FLUID_STACK, oilDescriptionKey);
+
+		if (Config.STEEL_MANAGEMENT.get() >= 2) {
+			List<ItemStack> list = new ArrayList<>();
+			list.add(new ItemStack(ItemsRegistry.STEEL_BLOCK_ITEM.get()));
+			list.add(new ItemStack(ItemsRegistry.STEEL_INGOT.get()));
+			list.add(new ItemStack(ItemsRegistry.STEEL_NUGGET.get()));
+			registration.getIngredientManager().removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK, list);
+		}
 	}
 
 	// Oxygen Loading

--- a/src/main/resources/data/beyond_earth/recipes/steel_block.json
+++ b/src/main/resources/data/beyond_earth/recipes/steel_block.json
@@ -1,6 +1,12 @@
 {
   "group": "beyond_earth",
   "type": "minecraft:crafting_shaped",
+  "conditions": [
+    {
+        "type": "beyond_earth:steel_management",
+		"level": 2
+    }
+  ],
   "pattern": [
     "###",
     "#*#",

--- a/src/main/resources/data/beyond_earth/recipes/steel_ingot.json
+++ b/src/main/resources/data/beyond_earth/recipes/steel_ingot.json
@@ -1,6 +1,12 @@
 {
   "group": "beyond_earth",
   "type": "minecraft:crafting_shaped",
+  "conditions": [
+    {
+        "type": "beyond_earth:steel_management",
+		"level": 2
+    }
+  ],
   "pattern": [
     "0"
   ],

--- a/src/main/resources/data/beyond_earth/recipes/steel_ingot_blasting.json
+++ b/src/main/resources/data/beyond_earth/recipes/steel_ingot_blasting.json
@@ -1,5 +1,11 @@
 {
     "type": "minecraft:blasting",
+	"conditions": [
+        {
+            "type": "beyond_earth:steel_management",
+            "level": 1
+        }
+    ],
     "ingredient": {
         "item": "minecraft:iron_ingot"
     },

--- a/src/main/resources/data/beyond_earth/recipes/steel_ingot_from_nugget.json
+++ b/src/main/resources/data/beyond_earth/recipes/steel_ingot_from_nugget.json
@@ -1,5 +1,11 @@
 {
   "type": "minecraft:crafting_shaped",
+  "conditions": [
+    {
+        "type": "beyond_earth:steel_management",
+		"level": 2
+    }
+  ],
   "group": "beyond_earth:steel_ingot",
   "result": {
     "item": "beyond_earth:steel_ingot"

--- a/src/main/resources/data/beyond_earth/recipes/steel_nugget_from_ingot.json
+++ b/src/main/resources/data/beyond_earth/recipes/steel_nugget_from_ingot.json
@@ -1,5 +1,11 @@
 {
   "type": "minecraft:crafting_shapeless",
+  "conditions": [
+    {
+        "type": "beyond_earth:steel_management",
+		"level": 2
+    }
+  ],
   "group": "beyond_earth:steel_nugget",
   "result": {
     "item": "beyond_earth:steel_nugget",


### PR DESCRIPTION
Idea from #170 and #116, #39 etc..

![image](https://user-images.githubusercontent.com/44163945/190392901-ef999e84-b88d-4dd8-abf8-76f51f107c31.png)

* This config can set steel ingredient items visibility as 3 levels

0. Don't change anything<br>use as-is provided by Beyond Earth
1. Disable Steel Ingot Recipe from Iron Ingot via Blasting<br>Respect Beyond Earth's Steel Items<br>Steel Item's can use
2. And hide steel items from JEI ingredients and item list<br>Just hide, Even if player get that items in some way, their can be still use (e.g. Loot Table)

If hide from JEI, Doesn't appear as a replacement item in recipes using each tag (e.g. forge:ingots/steel)
![image](https://user-images.githubusercontent.com/44163945/190398190-e6870f70-b69e-4ac0-9085-3db51c8c5b09.png)

And can't search like this
![image](https://user-images.githubusercontent.com/44163945/190397906-36590096-f17b-49b0-acbf-39647da2715d.png)
