### PR TITLE
Fix missing call slot.onTake

### DIFF
--- a/src/main/java/net/mrscauthd/beyond_earth/common/menus/helper/MenuHelper.java
+++ b/src/main/java/net/mrscauthd/beyond_earth/common/menus/helper/MenuHelper.java
@@ -80,6 +80,12 @@ public class MenuHelper {
             } else {
                 slot.setChanged();
             }
+
+            if (slotStack.getCount() == itemStack.getCount()) {
+                return ItemStack.EMPTY;
+            }
+
+            slot.onTake(player, slotStack);
         }
 
         return itemStack;


### PR DESCRIPTION
Call slot.onTake(Player, ItemStack) before MenuHelper#transferStackInSlot return

That method should be called return AbstractContainerMenu#quickMoveStack
I referenced Minecraft native ContainerMenus (AbstractFurnaceMenu, CraftingMenu)

![image](https://user-images.githubusercontent.com/44163945/197471720-1b823908-e4fb-41f6-9253-450fa99e7122.png)
